### PR TITLE
A-667: Identify and fix server channel reception issue

### DIFF
--- a/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
+++ b/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
@@ -17,7 +17,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.channel
 import monix.eval.Task
 import monix.reactive.Observable
-import monix.reactive.subjects.{PublishSubject, ReplaySubject, Subject}
+import monix.reactive.subjects.{ReplaySubject, Subject}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -34,7 +34,7 @@ class UDPPeerGroup[M](val config: Config)(implicit codec: Codec[M], bufferInstan
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val channelSubject = PublishSubject[Channel[InetMultiAddress, M]]()
+  private val channelSubject = ReplaySubject[Channel[InetMultiAddress, M]]()
 
   private val workerGroup = new NioEventLoopGroup()
 


### PR DESCRIPTION
Problem:
- UDPPeergroup returns a monix PublishSubject to expose the stream of channels that a peer receives to communicate with clients.
  This has the characteristic that, no channel received before the subscription to the `server()` stream will actually be notified to the user.
- This commit changes the use of PublishSubject for ReplaySubject. The semantics of ReplaySubject is that the channels received before the
  subscription will arrive to the user. This is the same behaviour we have in the `in` method of UPD channels's implementation.

Consider
- This solves a requirement need, however, this could also create problems in other use cases.
  A proper solution should be discussed.