### PR TITLE
A-802 Remove size method from Codec to comply with new interface

### DIFF
--- a/scalanet/src/io/iohk/scalanet/codec/FramingCodec.scala
+++ b/scalanet/src/io/iohk/scalanet/codec/FramingCodec.scala
@@ -34,8 +34,6 @@ class FramingCodec[T](val messageCodec: Codec[T], val maxFrameLength: Int = Int.
     s
   }
 
-  override def size(t: T): Int = 4 + messageCodec.size(t)
-
   override def encodeImpl(t: T, start: Int, destination: ByteBuffer): Unit = {
     destination.putInt(start, destination.capacity() - 4)
     messageCodec.encodeImpl(t, 4, destination)


### PR DESCRIPTION
This PR is supposed to be merged together with Snappy for decco: https://github.com/input-output-hk/decco/pull/24