### PR TITLE
Document possible options for addressing

### DIFF
--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -120,6 +120,12 @@ trait PeerGroup[A, M] {
   def shutdown(): Task[Unit]
 }
 
+trait Connection[M] {
+  def from: InetMultiAddress
+  def sendMessage(m: M): Task[Unit]
+  def close(): Task[Unit]
+}
+
 object PeerGroup {
 
   abstract class TerminalPeerGroup[A, M](implicit codec: Codec[M]) extends PeerGroup[A, M]
@@ -149,6 +155,8 @@ object PeerGroup {
         case HandshakeFailed(failure) => failure
       }
     }
+
+    case class NewConnectionArrived[A, M](connection: Connection[M]) extends ServerEvent[A, M]
 
     implicit class ServerOps[A, M](observable: Observable[ServerEvent[A, M]]) {
       def collectChannelCreated: Observable[Channel[A, M]] = observable.collect(ChannelCreated.collector)

--- a/scalanet/src/io/iohk/scalanet/peergroup/SimplePeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/SimplePeerGroup.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import io.iohk.decco._
 import io.iohk.scalanet.peergroup.PeerGroup.{HandshakeException, ServerEvent}
-import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.{ChannelCreated, HandshakeFailed}
+import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.{ChannelCreated, HandshakeFailed, NewConnectionArrived}
 import io.iohk.scalanet.peergroup.SimplePeerGroup.{Config, _}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -56,6 +56,7 @@ class SimplePeerGroup[A, AA, M](
         ChannelCreated(new ChannelImpl(a, List(underlyingChannel)))
       case HandshakeFailed(failure) =>
         HandshakeFailed[A, M](new HandshakeException[A](reverseLookup(failure.to), failure.cause))
+      case NewConnectionArrived(connection) => ???
     }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/StaticAddressMappedPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/StaticAddressMappedPeerGroup.scala
@@ -36,6 +36,7 @@ class StaticAddressMappedPeerGroup[A, AA, M](
         ChannelCreated(new ChannelImpl(a, underlyingChannel))
       case HandshakeFailed(failure) =>
         HandshakeFailed[A, M](new HandshakeException[A](reverseLookup(failure.to), failure.cause))
+      case NewConnectionArrived(connection) => ???
     }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/addressing/ControlMessageAddressing.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/addressing/ControlMessageAddressing.scala
@@ -1,0 +1,89 @@
+package io.iohk.scalanet.peergroup.addressing
+import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
+import ControlMessageAddressing.{ControlMessage, ControlMessageChannel}
+import io.iohk.scalanet.peergroup.PeerGroup.{HandshakeException, ServerEvent}
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+abstract class ControlMessageAddressing[A, U, M](
+    applicationAddress: A,
+    underlyingPeerGroup: PeerGroup[U, ControlMessage[A, M]]
+)(implicit scheduler: Scheduler)
+    extends PeerGroup[A, M] {
+
+  def underlying(address: A): U
+
+  override def processAddress: A = applicationAddress
+
+  override def initialize(): Task[Unit] = underlyingPeerGroup.initialize()
+
+  override def client(to: A): Task[Channel[A, M]] =
+    underlyingPeerGroup.client(underlying(to)) map { ch =>
+      ControlMessageChannel(processAddress, to, ch)
+    }
+
+  override def server(): Observable[PeerGroup.ServerEvent[A, M]] = {
+    underlyingPeerGroup.server().flatMap {
+      case ServerEvent.ChannelCreated(channel) =>
+        Observable.fromTask {
+          for {
+            _ <- channel.sendMessage(ControlMessage.Address(processAddress))
+            from <- channel.in.collect { case ControlMessage.Address(remote) => remote }.headL
+          } yield ServerEvent.ChannelCreated(ControlMessageChannel(processAddress, from, channel))
+        }
+      case ServerEvent.HandshakeFailed(failure) =>
+        Observable.fromTask {
+          Task.now {
+            // Note that we can't report the external address
+            val wrongAddressToReport = processAddress
+            ServerEvent.HandshakeFailed(new HandshakeException[A](wrongAddressToReport, failure.cause))
+          }
+        }
+      case ServerEvent.NewConnectionArrived(connection) => ???
+    }
+  }
+
+  override def shutdown(): Task[Unit] = underlyingPeerGroup.shutdown()
+}
+
+object ControlMessageAddressing {
+
+  case class ControlMessageChannel[A, U, M](
+      sourceAddress: A,
+      destination: A,
+      underlyingChannel: Channel[U, ControlMessage[A, M]]
+  )(implicit scheduler: Scheduler)
+      extends Channel[A, M] {
+
+    // We could send the control message right now on channel creation
+    // underlyingChannel.sendMessage(ControlMessage.Address(sourceAddress)).runAsync
+    // However, in this sketch we just reply to the server request
+    underlyingChannel.in.foreach {
+      case ControlMessage.Address(a) =>
+        assert(a == to) // possible check
+        underlyingChannel.sendMessage(ControlMessage.Address(sourceAddress)).runAsync
+      case _ =>
+    }
+
+    override def to: A = destination
+
+    override def sendMessage(message: M): Task[Unit] = {
+      underlyingChannel.sendMessage(ControlMessage.Message(message))
+    }
+
+    override def in: Observable[M] =
+      underlyingChannel.in.collect {
+        case ControlMessage.Message(message) => message
+      }
+
+    override def close(): Task[Unit] = underlyingChannel.close()
+  }
+
+  sealed trait ControlMessage[+A, +M]
+  object ControlMessage {
+    case class Address[A](address: A) extends ControlMessage[A, Nothing]
+    case class Message[M](message: M) extends ControlMessage[Nothing, M]
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressing.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressing.scala
@@ -1,0 +1,88 @@
+package io.iohk.scalanet.peergroup.addressing
+import io.iohk.scalanet.peergroup.PeerGroup.{HandshakeException, ServerEvent}
+import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
+import io.iohk.scalanet.peergroup.addressing.HeaderAddressing.{Header, HeaderChannel}
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+abstract class HeaderAddressing[A, U, M](
+    applicationAddress: A,
+    underlyingPeerGroup: PeerGroup[U, Header[A, M]]
+)(implicit scheduler: Scheduler)
+    extends PeerGroup[A, M] {
+
+  def underlying(address: A): U
+
+  override def processAddress: A = applicationAddress
+
+  override def initialize(): Task[Unit] = underlyingPeerGroup.initialize()
+
+  override def client(to: A): Task[Channel[A, M]] =
+    underlyingPeerGroup.client(underlying(to)) map { ch =>
+      HeaderChannel(processAddress, to, ch)
+    }
+
+  override def server(): Observable[PeerGroup.ServerEvent[A, M]] = underlyingPeerGroup.server().flatMap {
+    case ServerEvent.ChannelCreated(channel) =>
+      Observable.fromTask {
+        for {
+          _ <- channel.sendMessage(Header.Address(processAddress))
+          from <- channel.in.collect { case Header.Address(remote) => remote }.headL
+        } yield ServerEvent.ChannelCreated(HeaderChannel(processAddress, from, channel))
+      }
+    case ServerEvent.HandshakeFailed(failure) =>
+      Observable.fromTask {
+        Task.now {
+          // Note that we can't report the external address
+          val wrongAddressToReport = processAddress
+          ServerEvent.HandshakeFailed(new HandshakeException[A](wrongAddressToReport, failure.cause))
+        }
+      }
+    case ServerEvent.NewConnectionArrived(connection) => ???
+  }
+
+  override def shutdown(): Task[Unit] = underlyingPeerGroup.shutdown()
+}
+
+object HeaderAddressing {
+  sealed trait Header[+A, +M]
+  object Header {
+    case class Message[A, M](address: A, message: M) extends Header[A, M]
+    // note that this is needed because we receive ChannelCreated events without messages
+    // (triggered by connections) forcing us to add this control message. If we add a
+    // connection received event that provides a different class than Channel, we could
+    // avoid this extra control message. See HeaderAddressingWithConnection to see this
+    // implemented
+    case class Address[A](addres: A) extends Header[A, Nothing]
+  }
+
+  case class HeaderChannel[A, U, M](
+      sourceAddress: A,
+      destination: A,
+      underlyingChannel: Channel[U, Header[A, M]]
+  )(implicit scheduler: Scheduler)
+      extends Channel[A, M] {
+
+    underlyingChannel.in
+    underlyingChannel.in.foreach {
+      case Header.Address(a) =>
+        assert(a == to) // possible check
+        underlyingChannel.sendMessage(Header.Address(sourceAddress)).runAsync
+      case _ =>
+    }
+
+    override def to: A = destination
+
+    override def sendMessage(message: M): Task[Unit] = {
+      underlyingChannel.sendMessage(Header.Message(sourceAddress, message))
+    }
+
+    override def in: Observable[M] =
+      underlyingChannel.in.collect {
+        case Header.Message(sebder, message) if sebder == to => message
+      }
+
+    override def close(): Task[Unit] = underlyingChannel.close()
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingWithConnection.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingWithConnection.scala
@@ -1,0 +1,91 @@
+package io.iohk.scalanet.peergroup.addressing
+
+/** The idea here is to show again how the header idea can suit better when
+  * connection establishment events do not trigger Channel instances creation
+  * This allows to guarantee that whenever we want to build a channel, we have
+  * the a message in the `in` stream and hence we can extract the address from
+  * that message's header. This allows to remove handshakes.
+  */
+import io.iohk.scalanet.peergroup.PeerGroup.{HandshakeException, ServerEvent}
+import io.iohk.scalanet.peergroup.{Channel, Connection, InetMultiAddress, PeerGroup}
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import HeaderAddressingWithConnection._
+
+abstract class HeaderAddressingWithConnection[A, U, M](
+    applicationAddress: A,
+    underlyingPeerGroup: PeerGroup[U, Message[A, M]]
+)(implicit scheduler: Scheduler)
+    extends PeerGroup[A, M] {
+
+  def underlying(address: A): U
+
+  override def processAddress: A = applicationAddress
+
+  override def initialize(): Task[Unit] = underlyingPeerGroup.initialize()
+
+  override def client(to: A): Task[Channel[A, M]] =
+    underlyingPeerGroup.client(underlying(to)) map { ch =>
+      HeaderChannelWithConnection(processAddress, to, ch)
+    }
+
+  override def server(): Observable[PeerGroup.ServerEvent[A, M]] = underlyingPeerGroup.server().flatMap {
+    case ServerEvent.ChannelCreated(channel) =>
+      Observable.fromTask {
+        for {
+          from <- channel.in.collect { case Message(add, _) => add }.headL
+        } yield ServerEvent.ChannelCreated(HeaderChannelWithConnection(processAddress, from, channel))
+      }
+    case ServerEvent.HandshakeFailed(failure) =>
+      Observable.fromTask {
+        Task.now {
+          // Note that we can't report the external address
+          val wrongAddressToReport = processAddress
+          ServerEvent.HandshakeFailed(new HandshakeException[A](wrongAddressToReport, failure.cause))
+        }
+      }
+    case ServerEvent.NewConnectionArrived(connection) =>
+      Observable.fromTask {
+        Task.now {
+          ServerEvent.NewConnectionArrived(HeaderConnection(processAddress, connection))
+        }
+      }
+  }
+
+  override def shutdown(): Task[Unit] = underlyingPeerGroup.shutdown()
+}
+
+object HeaderAddressingWithConnection {
+  case class Message[A, M](address: A, message: M)
+
+  case class HeaderChannelWithConnection[A, U, M](
+      sourceAddress: A,
+      destination: A,
+      underlyingChannel: Channel[U, Message[A, M]]
+  )(implicit scheduler: Scheduler)
+      extends Channel[A, M] {
+
+    // NOTE: We now don't need to reply to a handshake here
+
+    override def to: A = destination
+
+    override def sendMessage(message: M): Task[Unit] = {
+      underlyingChannel.sendMessage(Message(sourceAddress, message))
+    }
+
+    override def in: Observable[M] =
+      underlyingChannel.in.collect {
+        case Message(sebder, message) if sebder == to => message
+      }
+
+    override def close(): Task[Unit] = underlyingChannel.close()
+  }
+
+  case class HeaderConnection[A, M](source: A, underlyingConnection: Connection[Message[A, M]]) extends Connection[M] {
+    override def from: InetMultiAddress = underlyingConnection.from
+    override def sendMessage(m: M): Task[Unit] =
+      underlyingConnection.sendMessage(Message(source, m))
+    override def close(): Task[Unit] = underlyingConnection.close()
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/addressing/README.md
+++ b/scalanet/src/io/iohk/scalanet/peergroup/addressing/README.md
@@ -1,0 +1,66 @@
+It seems to be the case that addressing can't be implemented as part
+of the basic peer groups (UDP, TCP, DTLS, TLS) because their
+underlying protocols do not support addressing itself (session endpoints
+identify communications but not the actual actor behind them).
+Lets see this with an example, Alice and Carlos could live behind a NAT
+and share a single IP, if they both start channels to Bob, then Bob would
+be able to distinguish the channels, but there is no information in the
+session endpoints (IP/Port pairs) that could allow Bob to know which
+conversation comes from Alice and which come from Carlos. Alice, Bob and
+Carlos would need to agree on how to identify conversations to their
+identities.
+
+One option to do this, is to send a control message at the start of a
+conversation that estates who is the sender of the message. This is
+implemented in ControlMessageAddressing,
+An alternative option is to add a header to messages to identify their
+source. This is implemented in HeaderAddressing. Both options present
+advantages and disadvantages:
+Control message based
+- Pros
+  + Minimal information overhead: The identifier is sent only once.
+- Cons
+  + If we don't send the control message at the very start, then we can
+    not define a value for the method `to` in `Channel` instances we
+    create for the `server` stream.
+  + The control message could get lost, then we would need to implement
+    an identification request message.
+
+Header based
+- Pros
+  + We will never fail to detect the source of a message.
+- Cons
+  + We can't define a value for the method `to` in `Channel` instances
+    we create for the `server` stream until we receive the first message
+    from the client. This forces to either separate connection creation
+    events from channel creation events (Done in
+    HeaderAddressingWithConnection) or add a control message to this
+    approach too (which brings the control message loss problem to this
+    approach too (This was implemented in HeaderAddressing).
+  + There is information overhead, a client only needs one identifier to
+    associate to the session endpoint (IP/Port) of a set of messages.
+    Once the IP/Port is associated to an id, resending the id does not
+    provide useful data at protocol level.
+
+In both cases we present a problem related to connection based protocols.
+In connection based protocols like TCP, scalanet creates a Channel
+instance as soon as a connection is accepted. This is a problem when we
+try to obtain the identifier of a connection at the server side, because
+no message is sent by the client yet. However, the channel is created and
+a value needs to be provided for the method `to` (in Channel interface).
+We could act in two ways to overcome that issue:
+1. Start a "handshake" from the server side requesting to the client to
+   send an identification message (this is the control message approach)
+2. Do not create a Channel instance on connection reception and only
+   create it on the first message arrival event. We could add a new event
+   `NewConnectionReceived` to provide a wrapper for the low level
+   connection concep (implemented with the `Connection` trait).
+
+Note that, at the point of connection reception (before receiving the
+first message), there is no way to know who is the actor behind a IP/Port
+pair.
+
+Problems
+- When to send the control message?
+- WHat to do with the not used header address in subsequent messages?
+- Should we hold the task until the addressing handshake is complete?

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/ControlMessageAddressingSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/ControlMessageAddressingSpec.scala
@@ -1,0 +1,80 @@
+package io.iohk.scalanet.peergroup.addressing
+
+import io.iohk.scalanet.peergroup.InMemoryPeerGroup
+import monix.execution.Scheduler
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+import io.iohk.scalanet.TaskValues._
+
+import scala.concurrent.Future
+import scala.util.Random
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures._
+
+class ControlMessageAddressingSpec extends FlatSpec with BeforeAndAfter {
+
+  import InMemoryPeerGroup.Network
+
+  val n: Network[Int, ControlMessageAddressing.ControlMessage[String, String]] =
+    new Network[Int, ControlMessageAddressing.ControlMessage[String, String]]()
+
+  before {
+    n.clear()
+  }
+
+  def twoRandomPeerGroup()(
+      implicit scheduler: Scheduler
+  ): (ControlMessageAddressing[String, Int, String], ControlMessageAddressing[String, Int, String]) = {
+    val rdmInMemoryPG1 =
+      new InMemoryPeerGroup[Int, ControlMessageAddressing.ControlMessage[String, String]](Random.nextInt())(n)
+    val rdmInMemoryPG2 =
+      new InMemoryPeerGroup[Int, ControlMessageAddressing.ControlMessage[String, String]](Random.nextInt())(n)
+    val peer1 = new ControlMessageAddressing[String, Int, String]("Ailce", rdmInMemoryPG1) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    val peer2 = new ControlMessageAddressing[String, Int, String]("Bob", rdmInMemoryPG2) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    (peer1, peer2)
+  }
+
+  "ControlMessage addressing" should "send and receive messages" in {
+    import monix.execution.Scheduler.Implicits.global
+    val (alice, bob) = twoRandomPeerGroup()
+
+    println(s"Alice: ${alice.processAddress}")
+    println(s"Bob: ${bob.processAddress}")
+
+    alice.initialize().evaluated
+    bob.initialize().evaluated
+
+    val alicesMessage = Random.alphanumeric.take(10).mkString
+    val bobsMessage = Random.alphanumeric.take(10).mkString
+
+    println(s"Alice's message: $alicesMessage")
+    println(s"Bob's message: $bobsMessage")
+
+    val bobReceived: Future[String] =
+      bob.server().collectChannelCreated.mergeMap(channel => channel.in).headL.runAsync
+    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runAsync)
+
+    val aliceClient = alice.client(bob.processAddress).evaluated
+    val aliceReceived = aliceClient.in.headL.runAsync
+    aliceClient.sendMessage(alicesMessage).runAsync
+
+    bobReceived.futureValue shouldBe alicesMessage
+    aliceReceived.futureValue shouldBe bobsMessage
+
+    println(s"Alice received: ${aliceReceived.futureValue}")
+    println(s"Bob received: ${bobReceived.futureValue}")
+
+    alice.shutdown().evaluated
+    bob.shutdown().evaluated
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingSpec.scala
@@ -1,0 +1,77 @@
+package io.iohk.scalanet.peergroup.addressing
+import io.iohk.scalanet.peergroup.InMemoryPeerGroup
+import monix.execution.Scheduler
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+import io.iohk.scalanet.TaskValues._
+
+import scala.concurrent.Future
+import scala.util.Random
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures._
+
+class HeaderAddressingSpec extends FlatSpec with BeforeAndAfter {
+
+  import InMemoryPeerGroup.Network
+
+  val n: Network[Int, HeaderAddressing.Header[String, String]] =
+    new Network[Int, HeaderAddressing.Header[String, String]]()
+
+  before {
+    n.clear()
+  }
+
+  def twoRandomPeerGroup()(
+      implicit scheduler: Scheduler
+  ): (HeaderAddressing[String, Int, String], HeaderAddressing[String, Int, String]) = {
+    val rdmInMemoryPG1 = new InMemoryPeerGroup[Int, HeaderAddressing.Header[String, String]](Random.nextInt())(n)
+    val rdmInMemoryPG2 = new InMemoryPeerGroup[Int, HeaderAddressing.Header[String, String]](Random.nextInt())(n)
+    val peer1 = new HeaderAddressing[String, Int, String]("Ailce", rdmInMemoryPG1) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    val peer2 = new HeaderAddressing[String, Int, String]("Bob", rdmInMemoryPG2) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    (peer1, peer2)
+  }
+
+  "Header addressing" should "send and receive messages" in {
+    import monix.execution.Scheduler.Implicits.global
+    val (alice, bob) = twoRandomPeerGroup()
+
+    println(s"Alice: ${alice.processAddress}")
+    println(s"Bob: ${bob.processAddress}")
+
+    alice.initialize().evaluated
+    bob.initialize().evaluated
+
+    val alicesMessage = Random.alphanumeric.take(10).mkString
+    val bobsMessage = Random.alphanumeric.take(10).mkString
+
+    println(s"Alice's message: $alicesMessage")
+    println(s"Bob's message: $bobsMessage")
+
+    val bobReceived: Future[String] =
+      bob.server().collectChannelCreated.mergeMap(channel => channel.in).headL.runAsync
+    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runAsync)
+
+    val aliceClient = alice.client(bob.processAddress).evaluated
+    val aliceReceived = aliceClient.in.headL.runAsync
+    aliceClient.sendMessage(alicesMessage).runAsync
+
+    bobReceived.futureValue shouldBe alicesMessage
+    aliceReceived.futureValue shouldBe bobsMessage
+
+    println(s"Alice received: ${aliceReceived.futureValue}")
+    println(s"Bob received: ${bobReceived.futureValue}")
+
+    alice.shutdown().evaluated
+    bob.shutdown().evaluated
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingWithConnectionSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/addressing/HeaderAddressingWithConnectionSpec.scala
@@ -1,0 +1,80 @@
+package io.iohk.scalanet.peergroup.addressing
+
+import io.iohk.scalanet.peergroup.InMemoryPeerGroup
+import monix.execution.Scheduler
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+import io.iohk.scalanet.TaskValues._
+
+import scala.concurrent.Future
+import scala.util.Random
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures._
+
+class HeaderAddressingWithConnectionSpec extends FlatSpec with BeforeAndAfter {
+
+  import InMemoryPeerGroup.Network
+
+  val n: Network[Int, HeaderAddressingWithConnection.Message[String, String]] =
+    new Network[Int, HeaderAddressingWithConnection.Message[String, String]]()
+
+  before {
+    n.clear()
+  }
+
+  def twoRandomPeerGroup()(
+      implicit scheduler: Scheduler
+  ): (HeaderAddressingWithConnection[String, Int, String], HeaderAddressingWithConnection[String, Int, String]) = {
+    val rdmInMemoryPG1 =
+      new InMemoryPeerGroup[Int, HeaderAddressingWithConnection.Message[String, String]](Random.nextInt())(n)
+    val rdmInMemoryPG2 =
+      new InMemoryPeerGroup[Int, HeaderAddressingWithConnection.Message[String, String]](Random.nextInt())(n)
+    val peer1 = new HeaderAddressingWithConnection[String, Int, String]("Ailce", rdmInMemoryPG1) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    val peer2 = new HeaderAddressingWithConnection[String, Int, String]("Bob", rdmInMemoryPG2) {
+      override def underlying(address: String): Int = {
+        if (address == "Alice") rdmInMemoryPG1.processAddress
+        else rdmInMemoryPG2.processAddress
+      }
+    }
+    (peer1, peer2)
+  }
+
+  "Header addressing" should "send and receive messages" in {
+    import monix.execution.Scheduler.Implicits.global
+    val (alice, bob) = twoRandomPeerGroup()
+
+    println(s"Alice: ${alice.processAddress}")
+    println(s"Bob: ${bob.processAddress}")
+
+    alice.initialize().evaluated
+    bob.initialize().evaluated
+
+    val alicesMessage = Random.alphanumeric.take(10).mkString
+    val bobsMessage = Random.alphanumeric.take(10).mkString
+
+    println(s"Alice's message: $alicesMessage")
+    println(s"Bob's message: $bobsMessage")
+
+    val bobReceived: Future[String] =
+      bob.server().collectChannelCreated.mergeMap(channel => channel.in).headL.runAsync
+    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runAsync)
+
+    val aliceClient = alice.client(bob.processAddress).evaluated
+    val aliceReceived = aliceClient.in.headL.runAsync
+    aliceClient.sendMessage(alicesMessage).runAsync
+
+    bobReceived.futureValue shouldBe alicesMessage
+    aliceReceived.futureValue shouldBe bobsMessage
+
+    println(s"Alice received: ${aliceReceived.futureValue}")
+    println(s"Bob received: ${bobReceived.futureValue}")
+
+    alice.shutdown().evaluated
+    bob.shutdown().evaluated
+  }
+
+}


### PR DESCRIPTION
This PR shows three sketch implementations for addressing.
One is based on control messages and two other messages are related to headers.
One of the header approaches separates the notions of Channels and Connections.
The other header approach mixes the notion of a header and the need for a control message.