### PR TITLE
Implement kademlia PING RPC.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -41,7 +41,7 @@ object scalanet extends ScalaModule with PublishModule {
   )
 
   override def ivyDeps = Agg(
-    ivy"io.monix::monix:3.0.0-RC1",
+    ivy"io.monix::monix:3.0.0",
     ivy"com.chuusai::shapeless:2.3.3",
     ivy"org.slf4j:slf4j-api:1.7.25",
     ivy"io.netty:netty-all:4.1.31.Final",
@@ -101,7 +101,7 @@ object scalanet extends ScalaModule with PublishModule {
       ivy"com.github.pureconfig::pureconfig:0.11.1",
       ivy"com.github.scopt::scopt:3.7.1",
       ivy"org.scodec::scodec-bits:1.1.6",
-      ivy"io.monix::monix:3.0.0-RC1",
+      ivy"io.monix::monix:3.0.0",
       ivy"org.scala-lang.modules::scala-parser-combinators:1.1.2"
     )
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/DTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/DTLSPeerGroup.scala
@@ -13,7 +13,7 @@ import io.iohk.scalanet.peergroup.InetPeerGroupUtils.{ChannelId, _}
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
 import io.iohk.scalanet.peergroup.PeerGroup.{MessageMTUException, ServerEvent}
 import monix.eval.Task
-import monix.execution.{Cancelable, Scheduler}
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.{PublishSubject, ReplaySubject, Subject}
 import org.eclipse.californium.elements._
@@ -73,7 +73,7 @@ class DTLSPeerGroup[M](val config: Config)(
       val buffer = codec.encode(message)
 
       Task
-        .async[Unit] { (_, c) =>
+        .async[Unit] { c =>
           val messageCallback = new MessageCallback {
             override def onConnecting(): Unit = ()
             override def onDtlsRetransmission(i: Int): Unit = ()
@@ -92,8 +92,6 @@ class DTLSPeerGroup[M](val config: Config)(
             RawData.outbound(buffer.toArray, new AddressEndpointContext(to.inetSocketAddress), messageCallback, false)
 
           dtlsConnector.send(rawData)
-
-          Cancelable.empty
         }
     }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -170,7 +170,7 @@ object PeerGroup {
       implicit scheduler: Scheduler
   ): Either[InitializationError, PG] =
     try {
-      Await.result(pg.initialize().runAsync, Duration.Inf)
+      Await.result(pg.initialize().runToFuture, Duration.Inf)
       Right(pg)
     } catch {
       case t: Throwable =>
@@ -193,7 +193,7 @@ object PeerGroup {
   ): PG =
     try {
       val peerGroup = pg
-      Await.result(peerGroup.initialize().runAsync, Duration.Inf)
+      Await.result(peerGroup.initialize().runToFuture, Duration.Inf)
       peerGroup
     } catch {
       case t: Throwable =>

--- a/scalanet/src/io/iohk/scalanet/peergroup/SimplePeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/SimplePeerGroup.scala
@@ -97,7 +97,7 @@ class SimplePeerGroup[A, AA, M](
           channel =>
             channel
               .sendMessage(Left(EnrolMe(processAddress, config.multicastAddresses, underLyingPeerGroup.processAddress)))
-              .runAsync
+              .runToFuture
         )
 
       enrolledTask
@@ -157,7 +157,7 @@ class SimplePeerGroup[A, AA, M](
     val enrolledReply = Enrolled(address, underlyingAddress, routingTable.toMap, multiCastTable.toMap)
     underLyingPeerGroup
       .client(underlyingAddress)
-      .foreach(channel => channel.sendMessage(Left(enrolledReply)).runAsync)
+      .foreach(channel => channel.sendMessage(Left(enrolledReply)).runToFuture)
   }
 
   private def debug(logMsg: String): Unit = {

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KMessage.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KMessage.scala
@@ -16,11 +16,15 @@ object KMessage {
 
   object KRequest {
     case class FindNodes[A](requestId: UUID, nodeRecord: NodeRecord[A], targetNodeId: BitVector) extends KRequest[A]
+
+    case class Ping[A](requestId: UUID, nodeRecord: NodeRecord[A]) extends KRequest[A]
   }
 
   sealed trait KResponse[A] extends KMessage[A]
 
   object KResponse {
     case class Nodes[A](requestId: UUID, nodeRecord: NodeRecord[A], nodes: Seq[NodeRecord[A]]) extends KResponse[A]
+
+    case class Pong[A](requestId: UUID, nodeRecord: NodeRecord[A]) extends KResponse[A]
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetwork.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetwork.scala
@@ -48,7 +48,7 @@ object KNetwork {
     }
 
     override def findNodes: Observable[(FindNodes[A], Nodes[A] => Task[Unit])] = {
-      peerGroup.server().collectChannelCreated.mapTask { channel: Channel[A, KMessage[A]] =>
+      peerGroup.server().collectChannelCreated.mapEval { channel: Channel[A, KMessage[A]] =>
         channel.in
           .collect {
             case f @ FindNodes(_, _, _) =>

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetworkRequestProcessing.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetworkRequestProcessing.scala
@@ -1,0 +1,65 @@
+package io.iohk.scalanet.peergroup.kademlia
+
+import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+/**
+  * If a user of KNetwork wanted to consume only one kind of request,
+  * it is not sufficient to collect or filter the request stream, since it is
+  * still necessary to close channels for excluded request types.
+  * The code to do this is demonstrated here.
+  */
+object KNetworkRequestProcessing {
+
+  implicit class KNetworkExtension[A](kNetwork: KNetwork[A])(implicit scheduler: Scheduler) {
+
+    type KRequestT = (KRequest[A], Option[KResponse[A]] => Task[Unit])
+    type FindNodesT = (FindNodes[A], Option[Nodes[A]] => Task[Unit])
+    type PingT = (Ping[A], Option[Pong[A]] => Task[Unit])
+
+    def findNodesRequests(): Observable[FindNodesT] = ignoringPing(kNetwork.kRequests).collect {
+      case (f @ FindNodes(_, _, _), h) => (f, h)
+    }
+
+    def pingRequests(): Observable[PingT] =
+      ignoringFindNodes(kNetwork.kRequests).collect {
+        case (p @ Ping(_, _), h) => (p, h)
+      }
+
+    private def ignoringPing(
+        kRequests: Observable[KRequestT]
+    ): Observable[KRequestT] = kRequests.map {
+      case (request, handler) =>
+        kRequestCatamorph[KRequestT](
+          (_, handler),
+          (_, ignore(handler))
+        )(request)
+    }
+
+    private def ignoringFindNodes(
+        kRequests: Observable[KRequestT]
+    ): Observable[KRequestT] = kRequests.map {
+      case (request, handler) =>
+        kRequestCatamorph[KRequestT](
+          (_, ignore(handler)),
+          (_, handler)
+        )(request)
+    }
+
+    private def kRequestCatamorph[T](fFindNodes: FindNodes[A] => T, fPing: Ping[A] => T): KRequest[A] => T = {
+      case f @ FindNodes(_, _, _) => fFindNodes(f)
+      case p @ Ping(_, _) => fPing(p)
+    }
+
+    private def ignore(
+        handler: Option[KResponse[A]] => Task[Unit]
+    ): Option[KResponse[A]] => Task[Unit] = {
+      handler(None).runToFuture
+      _ => Task.unit
+    }
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroup.scala
@@ -103,7 +103,7 @@ class KPeerGroup[A, M](
     debug(s"Setting up new channel to $nodeRecord.")
 
     // send the peer our own node record
-    channel.sendMessage(Left(kRouter.config.nodeRecord)).runAsync.foreach { _ =>
+    channel.sendMessage(Left(kRouter.config.nodeRecord)).runToFuture.foreach { _ =>
       debug(s"Acknowledgement sent to $nodeRecord.")
 
       val newChannel = new ChannelImpl[A, M](

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -50,7 +50,7 @@ class KRouter[A](val config: Config[A], val network: KNetwork[A])(
       )
       add(nodeRecord)
       val result = embellish(kBuckets.closestNodes(targetNodeId, config.k))
-      responseHandler(Nodes(uuid, config.nodeRecord, result)).runAsync
+      responseHandler(Nodes(uuid, config.nodeRecord, result)).runToFuture
         .onComplete {
           case Failure(t) =>
             log.info(
@@ -136,7 +136,7 @@ class KRouter[A](val config: Config[A], val network: KNetwork[A])(
 
           kNodesResponse.nodes
         }
-        .runAsync
+        .runToFuture
         .recover {
           case t: Throwable =>
             info(s"Query to node $knownNode failed due to exception $t.")

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -40,8 +40,9 @@ class KRouter[A](val config: Config[A], val network: KNetwork[A])(
       )
   }
 
+  import KNetworkRequestProcessing._
   // Handle findNodes requests...
-  network.findNodes.foreach {
+  network.findNodesRequests().foreach {
     case (findNodesRequest, responseHandler) =>
       val FindNodes(uuid, nodeRecord, targetNodeId) = findNodesRequest
 
@@ -50,7 +51,7 @@ class KRouter[A](val config: Config[A], val network: KNetwork[A])(
       )
       add(nodeRecord)
       val result = embellish(kBuckets.closestNodes(targetNodeId, config.k))
-      responseHandler(Nodes(uuid, config.nodeRecord, result)).runToFuture
+      responseHandler(Some(Nodes(uuid, config.nodeRecord, result))).runToFuture
         .onComplete {
           case Failure(t) =>
             log.info(

--- a/scalanet/src/io/iohk/scalanet/reactive/ObservableOps.scala
+++ b/scalanet/src/io/iohk/scalanet/reactive/ObservableOps.scala
@@ -1,0 +1,42 @@
+package io.iohk.scalanet.reactive
+
+import monix.execution.Scheduler
+import monix.reactive.Observable
+
+object ObservableOps {
+
+  implicit class ObservableExtension[T](o: Observable[T]) {
+
+    /**
+      * Split an observable by a predicate, placing values for which the predicate returns true
+      * to the right (and values for which the predicate returns false to the left).
+      * This is consistent with the convention adopted by Either.cond.
+      */
+    def split(
+        p: T => Boolean
+    )(implicit scheduler: Scheduler): (Observable[T], Observable[T]) = {
+      splitEither[T, T](elem => Either.cond(p(elem), elem, elem))
+    }
+
+    /**
+      * Split an observable into a pair of Observables, one left, one right, according
+      * to a determinant function.
+      */
+    def splitEither[U, V](
+        f: T => Either[U, V]
+    )(implicit scheduler: Scheduler): (Observable[U], Observable[V]) = {
+
+      val oo = o.map(f)
+
+      val l = oo.collect {
+        case Left(u) => u
+      }
+
+      val r = oo.collect {
+        case Right(v) => v
+      }
+
+      (l, r)
+    }
+  }
+}

--- a/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
@@ -89,7 +89,7 @@ object NetUtils {
       bufferInstantiator: BufferInstantiator[ByteBuffer]
   ): TCPPeerGroup[M] = {
     val pg = new TCPPeerGroup(TCPPeerGroup.Config(aRandomAddress()))
-    Await.result(pg.initialize().runAsync, 10 seconds)
+    Await.result(pg.initialize().runToFuture, 10 seconds)
     pg
   }
   def randomTLSPeerGroup[M](
@@ -99,7 +99,7 @@ object NetUtils {
   ): TLSPeerGroup[M] = {
     val sc1 = new SelfSignedCertificate()
     val pg = new TLSPeerGroup(TLSPeerGroup.Config(aRandomAddress(), sc1.key(), List(sc1.cert()), Nil))
-    Await.result(pg.initialize().runAsync, 10 seconds)
+    Await.result(pg.initialize().runToFuture, 10 seconds)
     pg
   }
 
@@ -109,7 +109,7 @@ object NetUtils {
       bufferInstantiator: BufferInstantiator[ByteBuffer]
   ): UDPPeerGroup[M] = {
     val pg = new UDPPeerGroup(UDPPeerGroup.Config(aRandomAddress()))
-    Await.result(pg.initialize().runAsync, 10 seconds)
+    Await.result(pg.initialize().runToFuture, 10 seconds)
     pg
   }
 
@@ -163,8 +163,8 @@ object NetUtils {
     val pg1 = new TLSPeerGroup(TLSPeerGroup.Config(address1, sc1.key(), List(sc1.cert()), List(sc2.cert()), clientAuth))
     val pg2 = new TLSPeerGroup(TLSPeerGroup.Config(address2, sc2.key(), List(sc2.cert()), List(sc1.cert()), clientAuth))
 
-    Await.result(pg1.initialize().runAsync, 10 seconds)
-    Await.result(pg2.initialize().runAsync, 10 seconds)
+    Await.result(pg1.initialize().runToFuture, 10 seconds)
+    Await.result(pg2.initialize().runToFuture, 10 seconds)
 
     (pg1, pg2)
   }
@@ -180,8 +180,8 @@ object NetUtils {
     val pg1 = new TCPPeerGroup(TCPPeerGroup.Config(address))
     val pg2 = new TCPPeerGroup(TCPPeerGroup.Config(address2))
 
-    Await.result(pg1.initialize().runAsync, 10 seconds)
-    Await.result(pg2.initialize().runAsync, 10 seconds)
+    Await.result(pg1.initialize().runToFuture, 10 seconds)
+    Await.result(pg2.initialize().runToFuture, 10 seconds)
 
     (pg1, pg2)
   }

--- a/scalanet/test/src/io/iohk/scalanet/TaskValues.scala
+++ b/scalanet/test/src/io/iohk/scalanet/TaskValues.scala
@@ -8,7 +8,7 @@ object TaskValues {
 
   implicit class TaskOps[T](task: Task[T]) {
     def evaluated(implicit scheduler: Scheduler, patienceConfig: PatienceConfig): T = {
-      task.runAsync.futureValue
+      task.runToFuture.futureValue
     }
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/DTLSPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/DTLSPeerGroupSpec.scala
@@ -33,9 +33,9 @@ class DTLSPeerGroupSpec extends FlatSpec {
 
   it should "report an error for a handshake failure -- server receives" in
     withTwoDTLSPeerGroups[String](duffKeyConfig) { (alice, bob) =>
-      val handshakeF = bob.server().collectHandshakeFailure.headL.runAsync
+      val handshakeF = bob.server().collectHandshakeFailure.headL.runToFuture
 
-      alice.client(bob.processAddress).evaluated.sendMessage("hello, bob").runAsync
+      alice.client(bob.processAddress).evaluated.sendMessage("hello, bob").runToFuture
 
       handshakeF.futureValue.to shouldBe alice.processAddress
     }
@@ -47,7 +47,7 @@ class DTLSPeerGroupSpec extends FlatSpec {
       val aliceClient = alice.client(bob.processAddress).evaluated
 
       val error = recoverToExceptionIf[HandshakeException[InetMultiAddress]] {
-        aliceClient.sendMessage(alicesMessage).runAsync
+        aliceClient.sendMessage(alicesMessage).runToFuture
       }.futureValue
 
       error.to shouldBe bob.processAddress
@@ -60,7 +60,7 @@ class DTLSPeerGroupSpec extends FlatSpec {
       val messageSize = Codec[Array[Byte]].encode(invalidMessage).capacity()
 
       val error = recoverToExceptionIf[MessageMTUException[InetMultiAddress]] {
-        alice.client(address).flatMap(channel => channel.sendMessage(invalidMessage)).runAsync
+        alice.client(address).flatMap(channel => channel.sendMessage(invalidMessage)).runToFuture
       }.futureValue
 
       error.size shouldBe messageSize
@@ -80,7 +80,7 @@ class DTLSPeerGroupSpec extends FlatSpec {
     val pg1 = dtlsPeerGroup[String](rawKeyConfig("alice"))
     isListeningUDP(pg1.config.bindAddress) shouldBe true
 
-    pg1.shutdown().runAsync.futureValue
+    pg1.shutdown().runToFuture.futureValue
 
     isListeningUDP(pg1.config.bindAddress) shouldBe false
   }
@@ -90,11 +90,11 @@ class DTLSPeerGroupSpec extends FlatSpec {
     val pg1 = new DTLSPeerGroup[String](config)
     val pg2 = new DTLSPeerGroup[String](config)
 
-    Await.result(pg1.initialize().runAsync, Duration.Inf)
+    Await.result(pg1.initialize().runToFuture, Duration.Inf)
     assertThrows[InitializationError] {
-      Await.result(pg2.initialize().runAsync, Duration.Inf)
+      Await.result(pg2.initialize().runToFuture, Duration.Inf)
     }
-    pg1.shutdown().runAsync.futureValue
+    pg1.shutdown().runToFuture.futureValue
 
   }
 }
@@ -150,7 +150,7 @@ object DTLSPeerGroupSpec {
       config: Config
   )(implicit codec: Codec[M], bufferInstantiator: BufferInstantiator[ByteBuffer]): DTLSPeerGroup[M] = {
     val pg = new DTLSPeerGroup[M](config)
-    Await.result(pg.initialize().runAsync, Duration.Inf)
+    Await.result(pg.initialize().runToFuture, Duration.Inf)
     pg
   }
 

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/PeerUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/PeerUtils.scala
@@ -33,13 +33,13 @@ trait PeerUtils[A, M, PG[_, _]] {
   )(implicit sc: Scheduler): Unit = {
     val alice = generateRandomPeerGroup()
     val bob = generateRandomPeerGroup()
-    initialize(alice).runAsync
-    initialize(bob).runAsync
+    initialize(alice).runToFuture
+    initialize(bob).runToFuture
     try {
       testFunction(alice, bob)
     } finally {
-      shutdown(alice).runAsync
-      shutdown(bob).runAsync
+      shutdown(alice).runToFuture
+      shutdown(bob).runToFuture
     }
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/SimplePeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/SimplePeerGroupSpec.scala
@@ -25,9 +25,9 @@ class SimplePeerGroupSpec extends FlatSpec {
 
   it should "send a message to itself" in withASimplePeerGroup("Alice") { alice =>
     val message = Random.alphanumeric.take(1044).mkString
-    val aliceReceived = alice.server().collectChannelCreated.mergeMap(_.in).headL.runAsync
+    val aliceReceived = alice.server().collectChannelCreated.mergeMap(_.in).headL.runToFuture
     val aliceClient: Channel[String, String] = alice.client(alice.processAddress).evaluated
-    aliceClient.sendMessage(message).runAsync
+    aliceClient.sendMessage(message).runToFuture
     aliceReceived.futureValue shouldBe message
   }
 
@@ -39,12 +39,12 @@ class SimplePeerGroupSpec extends FlatSpec {
     val alicesMessage = "hi bob, from alice"
     val bobsMessage = "hi alice, from bob"
 
-    val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runAsync
+    val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runToFuture
     bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).evaluated)
 
     val aliceClient = alice.client(bob.processAddress).evaluated
 
-    val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runAsync
+    val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runToFuture
     aliceClient.sendMessage(alicesMessage).evaluated
 
     bobReceived.futureValue shouldBe alicesMessage
@@ -59,12 +59,12 @@ class SimplePeerGroupSpec extends FlatSpec {
     val bobsMessage = "HI Alice"
     val alicesMessage = "HI Bob"
 
-    val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runAsync
+    val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runToFuture
     bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).evaluated)
 
     val aliceClient = alice.client(bob.processAddress).evaluated
 
-    val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runAsync
+    val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runToFuture
     aliceClient.sendMessage(alicesMessage).evaluated
 
     bobReceived.futureValue shouldBe alicesMessage
@@ -79,7 +79,7 @@ class SimplePeerGroupSpec extends FlatSpec {
         channel.in.filter(msg => msg == messageNews)
       }
       .headL
-      .runAsync
+      .runToFuture
 
     val sportUpdates = "Sports Updates"
 
@@ -90,7 +90,7 @@ class SimplePeerGroupSpec extends FlatSpec {
         channel.in.filter(msg => msg == sportUpdates)
       }
       .headL
-      .runAsync
+      .runToFuture
 
     val aliceClientNews = alice.client("news").evaluated
     val aliceClientSports = alice.client("sports").evaluated
@@ -113,12 +113,12 @@ class SimplePeerGroupSpec extends FlatSpec {
       val bobsMessage = "HI Alice"
       val alicesMessage = "HI Bob"
 
-      val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runAsync
+      val bobReceived = bob.server().collectChannelCreated.mergeMap(_.in).headL.runToFuture
       bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).evaluated)
 
       val aliceClient = alice.client(bob.processAddress).evaluated
 
-      val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runAsync
+      val aliceReceived = aliceClient.in.filter(msg => msg == bobsMessage).headL.runToFuture
       aliceClient.sendMessage(alicesMessage).evaluated
 
       bobReceived.futureValue shouldBe alicesMessage
@@ -133,7 +133,7 @@ class SimplePeerGroupSpec extends FlatSpec {
           channel.in.filter(msg => msg == messageNews)
         }
         .headL
-        .runAsync
+        .runToFuture
 
       val charlieReceivedNews = charlie
         .server()
@@ -142,7 +142,7 @@ class SimplePeerGroupSpec extends FlatSpec {
           channel.in.filter(msg => msg == messageNews)
         }
         .headL
-        .runAsync
+        .runToFuture
 
       val aliceClientNews = alice.client("news").evaluated
 
@@ -159,7 +159,7 @@ class SimplePeerGroupSpec extends FlatSpec {
           channel.in.filter(msg => msg == sportUpdates)
         }
         .headL
-        .runAsync
+        .runToFuture
 
       val charlieSportsUpdate = charlie
         .server()
@@ -168,7 +168,7 @@ class SimplePeerGroupSpec extends FlatSpec {
           channel.in.filter(msg => msg == sportUpdates)
         }
         .headL
-        .runAsync
+        .runToFuture
 
       val aliceSportsClient = alice.client("sports").evaluated
 
@@ -232,7 +232,7 @@ class SimplePeerGroupSpec extends FlatSpec {
       SimplePeerGroup.Config(bootstrapAddress, List.empty[String], Map.empty[String, InetMultiAddress]),
       bootStrapTerminalGroup
     )
-    bootstrap.initialize().runAsync.futureValue
+    bootstrap.initialize().runToFuture.futureValue
 
     val otherPeerGroups = addresses
       .map(
@@ -248,7 +248,7 @@ class SimplePeerGroupSpec extends FlatSpec {
       )
       .toList
 
-    val futures: Seq[Future[Unit]] = otherPeerGroups.map(pg => pg.initialize().runAsync)
+    val futures: Seq[Future[Unit]] = otherPeerGroups.map(pg => pg.initialize().runToFuture)
     Future.sequence(futures).futureValue
 
     val peerGroups = bootstrap :: otherPeerGroups

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/StandardTestPack.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/StandardTestPack.scala
@@ -17,12 +17,12 @@ object StandardTestPack {
     val bobsMessage = Random.alphanumeric.take(1024).mkString
 
     val bobReceived: Future[String] =
-      bob.server().collectChannelCreated.mergeMap(channel => channel.in).headL.runAsync
-    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runAsync)
+      bob.server().collectChannelCreated.mergeMap(channel => channel.in).headL.runToFuture
+    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runToFuture)
 
     val aliceClient = alice.client(bob.processAddress).evaluated
-    val aliceReceived = aliceClient.in.headL.runAsync
-    aliceClient.sendMessage(alicesMessage).runAsync
+    val aliceReceived = aliceClient.in.headL.runToFuture
+    aliceClient.sendMessage(alicesMessage).runToFuture
 
     bobReceived.futureValue shouldBe alicesMessage
     aliceReceived.futureValue shouldBe bobsMessage
@@ -33,16 +33,16 @@ object StandardTestPack {
   ): Unit = {
     val alicesMessage = Random.alphanumeric.take(1024).mkString
     val bobsMessage = Random.alphanumeric.take(1024).mkString
-    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runAsync)
+    bob.server().collectChannelCreated.foreach(channel => channel.sendMessage(bobsMessage).runToFuture)
 
     val aliceClient1 = alice.client(bob.processAddress).evaluated
     val aliceClient2 = alice.client(bob.processAddress).evaluated
 
-    val aliceReceived1 = aliceClient1.in.headL.runAsync
-    val aliceReceived2 = aliceClient2.in.headL.runAsync
+    val aliceReceived1 = aliceClient1.in.headL.runToFuture
+    val aliceReceived2 = aliceClient2.in.headL.runToFuture
 
-    aliceClient1.sendMessage(alicesMessage).runAsync
-    aliceClient2.sendMessage(alicesMessage).runAsync
+    aliceClient1.sendMessage(alicesMessage).runToFuture
+    aliceClient2.sendMessage(alicesMessage).runToFuture
 
     aliceReceived1.futureValue shouldBe bobsMessage
     aliceReceived2.futureValue shouldBe bobsMessage
@@ -55,7 +55,7 @@ object StandardTestPack {
   ): Unit = {
 
     val aliceError = recoverToExceptionIf[ChannelSetupException[InetMultiAddress]] {
-      alice.client(invalidAddress).runAsync
+      alice.client(invalidAddress).runToFuture
     }
 
     aliceError.futureValue.to shouldBe invalidAddress

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/TCPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/TCPPeerGroupSpec.scala
@@ -39,11 +39,11 @@ class TCPPeerGroupSpec extends FlatSpec with BeforeAndAfterAll {
   it should "report an error for messaging on a closed channel -- server closes" in
     withTwoRandomTCPPeerGroups[String] { (alice, bob) =>
       val alicesMessage = Random.alphanumeric.take(1024).mkString
-      bob.server().collectChannelCreated.foreachL(channel => channel.close().runAsync).runAsync
+      bob.server().collectChannelCreated.foreachL(channel => channel.close().runToFuture).runToFuture
 
       val aliceClient = alice.client(bob.processAddress).evaluated
       val aliceError = recoverToExceptionIf[ChannelBrokenException[InetMultiAddress]] {
-        aliceClient.sendMessage(alicesMessage).runAsync
+        aliceClient.sendMessage(alicesMessage).runToFuture
       }
 
       aliceError.futureValue.to shouldBe bob.processAddress
@@ -52,14 +52,14 @@ class TCPPeerGroupSpec extends FlatSpec with BeforeAndAfterAll {
   it should "report an error for messaging on a closed channel -- client closes" in
     withTwoRandomTCPPeerGroups[String] { (alice, bob) =>
       val bobsMessage = Random.alphanumeric.take(1024).mkString
-      bob.server().collectChannelCreated.foreachL(channel => channel.sendMessage(bobsMessage).runAsync).runAsync
+      bob.server().collectChannelCreated.foreachL(channel => channel.sendMessage(bobsMessage).runToFuture).runToFuture
       val bobChannel: CancelableFuture[Channel[InetMultiAddress, String]] =
-        bob.server().collectChannelCreated.headL.runAsync
+        bob.server().collectChannelCreated.headL.runToFuture
 
       val aliceClient = alice.client(bob.processAddress).evaluated
       aliceClient.close().evaluated
       val bobError = recoverToExceptionIf[ChannelBrokenException[InetMultiAddress]] {
-        bobChannel.futureValue.sendMessage(bobsMessage).runAsync
+        bobChannel.futureValue.sendMessage(bobsMessage).runToFuture
       }
 
       bobError.futureValue.to shouldBe alice.processAddress
@@ -74,7 +74,7 @@ class TCPPeerGroupSpec extends FlatSpec with BeforeAndAfterAll {
     val tcpPeerGroup = randomTCPPeerGroup[String]
     isListening(tcpPeerGroup.config.bindAddress) shouldBe true
 
-    tcpPeerGroup.shutdown().runAsync.futureValue
+    tcpPeerGroup.shutdown().runToFuture.futureValue
 
     isListening(tcpPeerGroup.config.bindAddress) shouldBe false
   }
@@ -88,11 +88,11 @@ class TCPPeerGroupSpec extends FlatSpec with BeforeAndAfterAll {
     val address = aRandomAddress()
     val pg1 = new TCPPeerGroup(TCPPeerGroup.Config(address))
     val pg2 = new TCPPeerGroup(TCPPeerGroup.Config(address))
-    Await.result(pg1.initialize().runAsync, 10 seconds)
+    Await.result(pg1.initialize().runToFuture, 10 seconds)
     assertThrows[InitializationError] {
-      Await.result(pg2.initialize().runAsync, 10 seconds)
+      Await.result(pg2.initialize().runToFuture, 10 seconds)
     }
-    pg1.shutdown().runAsync.futureValue
+    pg1.shutdown().runToFuture.futureValue
   }
 
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
@@ -31,7 +31,7 @@ class UDPPeerGroupSpec extends FlatSpec {
       val messageSize = Codec[Array[Byte]].encode(invalidMessage).capacity()
 
       val error = recoverToExceptionIf[MessageMTUException[InetMultiAddress]] {
-        alice.client(address).flatMap(channel => channel.sendMessage(invalidMessage)).runAsync
+        alice.client(address).flatMap(channel => channel.sendMessage(invalidMessage)).runToFuture
       }.futureValue
 
       error.size shouldBe messageSize
@@ -50,7 +50,7 @@ class UDPPeerGroupSpec extends FlatSpec {
     val pg1 = randomUDPPeerGroup[String]
     isListeningUDP(pg1.config.bindAddress) shouldBe true
 
-    pg1.shutdown().runAsync.futureValue
+    pg1.shutdown().runToFuture.futureValue
 
     isListeningUDP(pg1.config.bindAddress) shouldBe false
   }
@@ -60,11 +60,11 @@ class UDPPeerGroupSpec extends FlatSpec {
     val pg1 = new UDPPeerGroup[String](UDPPeerGroup.Config(address))
     val pg2 = new UDPPeerGroup[String](UDPPeerGroup.Config(address))
 
-    Await.result(pg1.initialize().runAsync, 10 seconds)
+    Await.result(pg1.initialize().runToFuture, 10 seconds)
     assertThrows[InitializationError] {
-      Await.result(pg2.initialize().runAsync, 10 seconds)
+      Await.result(pg2.initialize().runToFuture, 10 seconds)
     }
-    pg1.shutdown().runAsync.futureValue
+    pg1.shutdown().runToFuture.futureValue
   }
 
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
@@ -3,8 +3,8 @@ package io.iohk.scalanet.peergroup.kademlia
 import java.util.UUID
 import java.util.concurrent.TimeoutException
 
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.FindNodes
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.Nodes
+import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
 import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
 import io.iohk.scalanet.peergroup.kademlia.KNetwork.KNetworkScalanetImpl
 import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
@@ -13,7 +13,7 @@ import monix.reactive.Observable
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import org.scalatest.mockito.MockitoSugar._
-import org.mockito.Mockito.{verify, when, never}
+import org.mockito.Mockito.{never, verify, when}
 
 import scala.concurrent.duration._
 import monix.execution.Scheduler.Implicits.global
@@ -21,123 +21,150 @@ import org.scalatest.concurrent.ScalaFutures._
 import io.iohk.scalanet.TaskValues._
 import KNetworkSpec._
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
+import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
+import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class KNetworkSpec extends FlatSpec {
 
   implicit val patienceConfig = PatienceConfig(1 second)
 
-  "Server findNodes" should "not close server channels (it is the responsibility of the response handler)" in {
-    val (network, peerGroup) = createKNetwork
-    val channel = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.server()).thenReturn(Observable.eval(ChannelCreated(channel)))
-    when(channel.in).thenReturn(Observable.eval(findNodes))
-    when(channel.close()).thenReturn(Task.unit)
+  private val getFindNodesRequest: KNetwork[String] => Task[KRequest[String]] = getActualRequest(_.findNodes)
+  private val getPingRequest: KNetwork[String] => Task[KRequest[String]] = getActualRequest(_.ping)
 
-    val (request, _) = network.findNodes.headL.runAsync.futureValue
+  private val sendFindNodesResponse: Nodes[String] => KNetwork[String] => Task[Unit] = sendResponse(_.findNodes)
+  private val sendPingResponse: Pong[String] => KNetwork[String] => Task[Unit] = sendResponse(_.ping)
 
-    request shouldBe findNodes
-    verify(channel, never()).close()
-  }
+  private val sendFindNodesRequest: (NodeRecord[String], FindNodes[String]) => KNetwork[String] => Task[Nodes[String]] =
+    (to, request) => network => network.findNodes(to, request)
 
-  "Server findNodes" should "close server channels when a request does not arrive before a timeout" in {
-    val (network, peerGroup) = createKNetwork
-    val channel = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.server()).thenReturn(Observable.eval(ChannelCreated(channel)))
-    when(channel.in).thenReturn(Observable.never)
-    when(channel.close()).thenReturn(Task.unit)
+  private val sendPingRequest: (NodeRecord[String], Ping[String]) => KNetwork[String] => Task[Pong[String]] =
+    (to, request) => network => network.ping(to, request)
 
-    val t = network.findNodes.headL.runAsync.failed.futureValue
+  private val rpcs = Table(
+    ("Label", "Request", "Response", "Request extractor", "Response application", "Client RPC"),
+    (
+      "FIND_NODES",
+      findNodes,
+      nodes,
+      getFindNodesRequest,
+      sendFindNodesResponse(nodes),
+      sendFindNodesRequest(targetRecord, findNodes)
+    ),
+    ("PING", ping, pong, getPingRequest, sendPingResponse(pong), sendPingRequest(targetRecord, ping))
+  )
 
-    t shouldBe a[TimeoutException]
-    verify(channel).close()
-  }
+  forAll(rpcs) { (label, request, response, requestExtractor, responseApplication, clientRpc) =>
+    s"Server $label" should "not close server channels (it is the responsibility of the response handler)" in {
+      val (network, peerGroup) = createKNetwork
+      val channel = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.server())
+        .thenReturn(Observable.eval(ChannelCreated(channel)))
+      when(channel.in).thenReturn(Observable.eval(request))
+      when(channel.close()).thenReturn(Task.unit)
 
-  "Server findNodes" should "close server channel in the response task" in {
-    val (network, peerGroup) = createKNetwork
-    val channel = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.server()).thenReturn(Observable.eval(ChannelCreated(channel)))
-    when(channel.in).thenReturn(Observable.eval(findNodes))
-    when(channel.sendMessage(nodes)).thenReturn(Task.unit)
-    when(channel.close()).thenReturn(Task.unit)
+      val actualRequest = requestExtractor(network).runAsync.futureValue
 
-    val (_, responseHandler) = network.findNodes.headL.runAsync.futureValue
-    responseHandler(nodes).evaluated
+      actualRequest shouldBe request
+      verify(channel, never()).close()
+    }
 
-    verify(channel).close()
-  }
+    s"Server $label" should "close server channels when a request does not arrive before a timeout" in {
+      val (network, peerGroup) = createKNetwork
+      val channel = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.server())
+        .thenReturn(Observable.eval(ChannelCreated(channel)))
+      when(channel.in).thenReturn(Observable.never)
+      when(channel.close()).thenReturn(Task.unit)
 
-  "Server findNodes" should "close server channel in timed out response task" in {
-    val (network, peerGroup) = createKNetwork
-    val channel = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.server()).thenReturn(Observable.eval(ChannelCreated(channel)))
-    when(channel.in).thenReturn(Observable.eval(findNodes))
-    when(channel.sendMessage(nodes)).thenReturn(Task.never)
-    when(channel.close()).thenReturn(Task.unit)
+      val t = requestExtractor(network).runAsync.failed.futureValue
 
-    val (_, responseHandler) = network.findNodes.headL.runAsync.futureValue
-    val t = responseHandler(nodes).failed.evaluated
+      t shouldBe a[TimeoutException]
+      verify(channel).close()
+    }
 
-    t shouldBe a[TimeoutException]
-    verify(channel).close()
-  }
+    s"Server $label" should "close server channel in the response task" in {
+      val (network, peerGroup) = createKNetwork
+      val channel = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.server())
+        .thenReturn(Observable.eval(ChannelCreated(channel)))
+      when(channel.in).thenReturn(Observable.eval(request))
+      when(channel.sendMessage(response)).thenReturn(Task.unit)
+      when(channel.close()).thenReturn(Task.unit)
 
-  "Client findNodes" should "close client channels when requests are successful" in {
-    val (network, peerGroup) = createKNetwork
-    val client = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
-    when(client.sendMessage(findNodes)).thenReturn(Task.unit)
-    when(client.in).thenReturn(Observable.eval(nodes))
-    when(client.close()).thenReturn(Task.unit)
+      responseApplication(network).evaluated
 
-    val response: Nodes[String] =
-      network.findNodes(targetRecord, findNodes).evaluated
+      verify(channel).close()
+    }
 
-    response shouldBe nodes
-    verify(client).close()
-  }
+    s"Server $label" should "close server channel in timed out response task" in {
+      val (network, peerGroup) = createKNetwork
+      val channel = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.server())
+        .thenReturn(Observable.eval(ChannelCreated(channel)))
+      when(channel.in).thenReturn(Observable.eval(request))
+      when(channel.sendMessage(response)).thenReturn(Task.never)
+      when(channel.close()).thenReturn(Task.unit)
 
-  "Client findNodes" should "pass exception when client call fails" in {
-    val (network, peerGroup) = createKNetwork
-    val client = mock[Channel[String, KMessage[String]]]
-    val exception = new Exception("failed")
-    when(peerGroup.client(targetRecord.routingAddress))
-      .thenReturn(Task.raiseError(exception))
-    when(client.close()).thenReturn(Task.unit)
+      val t = responseApplication(network).failed.evaluated
 
-    val t: Throwable =
-      network.findNodes(targetRecord, findNodes).failed.evaluated
+      t shouldBe a[TimeoutException]
+      verify(channel).close()
+    }
 
-    t shouldBe exception
-  }
+    s"Client $label" should "close client channels when requests are successful" in {
+      val (network, peerGroup) = createKNetwork
+      val client = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
+      when(client.sendMessage(request)).thenReturn(Task.unit)
+      when(client.in).thenReturn(Observable.eval(response))
+      when(client.close()).thenReturn(Task.unit)
 
-  "Client findNodes" should "close client channels when sendMessage calls fail" in {
-    val (network, peerGroup) = createKNetwork
-    val client = mock[Channel[String, KMessage[String]]]
-    val exception = new Exception("failed")
-    when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
-    when(client.sendMessage(findNodes)).thenReturn(Task.raiseError(exception))
-    when(client.close()).thenReturn(Task.unit)
+      val actualResponse = clientRpc(network).evaluated
 
-    val t: Throwable =
-      network.findNodes(targetRecord, findNodes).failed.evaluated
+      actualResponse shouldBe response
+      verify(client).close()
+    }
 
-    t shouldBe exception
-    verify(client).close()
-  }
+    s"Client $label" should "pass exception when client call fails" in {
+      val (network, peerGroup) = createKNetwork
+      val client = mock[Channel[String, KMessage[String]]]
+      val exception = new Exception("failed")
+      when(peerGroup.client(targetRecord.routingAddress))
+        .thenReturn(Task.raiseError(exception))
+      when(client.close()).thenReturn(Task.unit)
 
-  "Client findNodes" should "close client channels when response fails to arrive" in {
-    val (network, peerGroup) = createKNetwork
-    val client = mock[Channel[String, KMessage[String]]]
-    when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
-    when(client.sendMessage(findNodes)).thenReturn(Task.unit)
-    when(client.in).thenReturn(Observable.fromTask(Task.never))
-    when(client.close()).thenReturn(Task.unit)
+      val t: Throwable = clientRpc(network).failed.evaluated
 
-    val t: Throwable =
-      network.findNodes(targetRecord, findNodes).failed.evaluated
+      t shouldBe exception
+    }
 
-    t shouldBe a[TimeoutException]
-    verify(client).close()
+    s"Client $label" should "close client channels when sendMessage calls fail" in {
+      val (network, peerGroup) = createKNetwork
+      val client = mock[Channel[String, KMessage[String]]]
+      val exception = new Exception("failed")
+      when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
+      when(client.sendMessage(request)).thenReturn(Task.raiseError(exception))
+      when(client.close()).thenReturn(Task.unit)
+
+      val t: Throwable = clientRpc(network).failed.evaluated
+
+      t shouldBe exception
+      verify(client).close()
+    }
+
+    s"Client $label" should "close client channels when response fails to arrive" in {
+      val (network, peerGroup) = createKNetwork
+      val client = mock[Channel[String, KMessage[String]]]
+      when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
+      when(client.sendMessage(request)).thenReturn(Task.unit)
+      when(client.in).thenReturn(Observable.fromTask(Task.never))
+      when(client.close()).thenReturn(Task.unit)
+
+      val t: Throwable = clientRpc(network).failed.evaluated
+
+      t shouldBe a[TimeoutException]
+      verify(client).close()
+    }
   }
 }
 
@@ -149,8 +176,24 @@ object KNetworkSpec {
   private val findNodes = FindNodes(uuid, nodeRecord, targetRecord.id)
   private val nodes = Nodes(uuid, targetRecord, Seq.empty)
 
+  private val ping = Ping(uuid, nodeRecord)
+  private val pong = Pong(uuid, targetRecord)
+
   private def createKNetwork: (KNetwork[String], PeerGroup[String, KMessage[String]]) = {
     val peerGroup = mock[PeerGroup[String, KMessage[String]]]
     (new KNetworkScalanetImpl(peerGroup, 50 millis), peerGroup)
+  }
+
+  private def getActualRequest[Request <: KRequest[String]](rpc: KNetwork[String] => Observable[(Request, _)])(
+      network: KNetwork[String]
+  ): Task[Request] = {
+    rpc(network).headL.map(_._1)
+  }
+
+  private def sendResponse[Request <: KRequest[String], Response <: KResponse[String]](
+      rpc: KNetwork[String] => Observable[(Request, Response => Task[Unit])]
+  )(response: Response)(network: KNetwork[String]): Task[Unit] = {
+    val (_, handler) = rpc(network).headL.runAsync.futureValue
+    handler(response)
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
@@ -33,7 +33,7 @@ class KNetworkSpec extends FlatSpec {
     when(channel.in).thenReturn(Observable.eval(findNodes))
     when(channel.close()).thenReturn(Task.unit)
 
-    val (request, _) = network.findNodes.headL.runAsync.futureValue
+    val (request, _) = network.findNodes.headL.runToFuture.futureValue
 
     request shouldBe findNodes
     verify(channel, never()).close()
@@ -46,7 +46,7 @@ class KNetworkSpec extends FlatSpec {
     when(channel.in).thenReturn(Observable.never)
     when(channel.close()).thenReturn(Task.unit)
 
-    val t = network.findNodes.headL.runAsync.failed.futureValue
+    val t = network.findNodes.headL.runToFuture.failed.futureValue
 
     t shouldBe a[TimeoutException]
     verify(channel).close()
@@ -60,7 +60,7 @@ class KNetworkSpec extends FlatSpec {
     when(channel.sendMessage(nodes)).thenReturn(Task.unit)
     when(channel.close()).thenReturn(Task.unit)
 
-    val (_, responseHandler) = network.findNodes.headL.runAsync.futureValue
+    val (_, responseHandler) = network.findNodes.headL.runToFuture.futureValue
     responseHandler(nodes).evaluated
 
     verify(channel).close()
@@ -74,7 +74,7 @@ class KNetworkSpec extends FlatSpec {
     when(channel.sendMessage(nodes)).thenReturn(Task.never)
     when(channel.close()).thenReturn(Task.unit)
 
-    val (_, responseHandler) = network.findNodes.headL.runAsync.futureValue
+    val (_, responseHandler) = network.findNodes.headL.runToFuture.futureValue
     val t = responseHandler(nodes).failed.evaluated
 
     t shouldBe a[TimeoutException]

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
@@ -84,8 +84,8 @@ object KPeerGroupSpec {
     try {
       testCode(kPeerGroup1, kPeerGroup2)
     } finally {
-      Await.result(kPeerGroup1.shutdown().runAsync, Duration.Inf)
-      Await.result(kPeerGroup1.shutdown().runAsync, Duration.Inf)
+      Await.result(kPeerGroup1.shutdown().runToFuture, Duration.Inf)
+      Await.result(kPeerGroup1.shutdown().runToFuture, Duration.Inf)
     }
   }
 

--- a/scalanet/test/src/io/iohk/scalanet/reactive/ObservableOpsSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/reactive/ObservableOpsSpec.scala
@@ -1,0 +1,37 @@
+package io.iohk.scalanet.reactive
+
+import io.iohk.scalanet.reactive.ObservableOps._
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import monix.reactive.subjects.PublishSubject
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures._
+
+class ObservableOpsSpec extends FlatSpec {
+
+  val isEven: Int => Boolean = _ % 2 == 0
+
+  "ObservableExtension" should "split a cold observable" in {
+    val o = Observable(1, 2, 3, 4, 5)
+
+    val (l, r) = o.split(isEven)
+
+    l.toListL.runAsync.futureValue shouldBe List(1, 3, 5)
+    r.toListL.runAsync.futureValue shouldBe List(2, 4)
+  }
+
+  it should "split a hot observable" in {
+    val o = PublishSubject[Int]()
+
+    val (l, r) = o.split(isEven)
+    val lbuf = l.toListL.runAsync
+    val rbuf = r.toListL.runAsync
+
+    Observable.fromIterable(1 to 5).mapFuture(i => o.onNext(i)).subscribe()
+    o.onComplete()
+
+    lbuf.futureValue shouldBe List(1, 3, 5)
+    rbuf.futureValue shouldBe List(2, 4)
+  }
+}


### PR DESCRIPTION
This is the implementation of the PING RPC. It is a pre-requisite for getting some of the time-dependent functionality working in kademlia, such as detecting nodes that have gone down.