### PR TITLE
[PM-853] Various improvements to krouter

### DIFF
--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
@@ -25,8 +25,7 @@ class AppContext(nodeConfig: KRouter.Config[InetMultiAddress])(implicit schedule
       val kNetwork =
         new KNetworkScalanetImpl[InetMultiAddress](routingPeerGroup)
 
-      new KRouter[InetMultiAddress](nodeConfig, kNetwork)
-
+      KRouter.startRouterWithServerSeq(nodeConfig, kNetwork).runSyncUnsafe()
     } catch {
       case e: Exception =>
         System.err.println(

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
@@ -48,7 +48,7 @@ trait CommandParser extends RegexParsers {
 
     case class DumpCommand() extends Command {
       override def applyTo(kRouter: KRouter[InetMultiAddress]): String = {
-        kRouter.nodeRecords.map { case (_, record) => Utils.recordToStr(record) }.mkString("\n")
+        kRouter.nodeRecords.runSyncUnsafe().map { case (_, record) => Utils.recordToStr(record) }.mkString("\n")
       }
     }
 

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
@@ -17,12 +17,11 @@ trait CommandParser extends RegexParsers {
   }
 
   object Command {
-    import scala.concurrent.ExecutionContext.Implicits.global
-
+    import monix.execution.Scheduler.Implicits.global
     case class GetCommand(nodeId: BitVector) extends Command {
       override def applyTo(kRouter: KRouter[InetMultiAddress]): String = {
         val p = Promise[String]()
-        kRouter.get(nodeId).onComplete {
+        kRouter.get(nodeId).runToFuture.onComplete {
           case util.Failure(exception) =>
             p.success(exception.getMessage)
           case util.Success(nodeRecord) =>
@@ -35,7 +34,7 @@ trait CommandParser extends RegexParsers {
     case class AddCommand(nodeRecord: NodeRecord[InetMultiAddress]) extends Command {
       val dumpCommand = DumpCommand()
       override def applyTo(kRouter: KRouter[InetMultiAddress]): String = {
-        kRouter.add(nodeRecord)
+        kRouter.add(nodeRecord).runToFuture
         dumpCommand.applyTo(kRouter)
       }
     }

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetwork.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KNetwork.scala
@@ -6,7 +6,6 @@ import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
 import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
 import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
 import monix.eval.Task
-import monix.execution.Scheduler
 import monix.reactive.Observable
 
 trait KNetwork[A] {
@@ -46,8 +45,7 @@ object KNetwork {
   class KNetworkScalanetImpl[A](
       val peerGroup: PeerGroup[A, KMessage[A]],
       val requestTimeout: FiniteDuration = 3 seconds
-  )(implicit scheduler: Scheduler)
-      extends KNetwork[A] {
+  ) extends KNetwork[A] {
 
     override lazy val kRequests: Observable[(KRequest[A], Option[KResponse[A]] => Task[Unit])] = {
       peerGroup

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroup.scala
@@ -52,8 +52,8 @@ class KPeerGroup[A, M](
     val p = Promise[Unit]()
     val pF = p.future
 
-    val underlyingChannelTask = Task
-      .fromFuture(kRouter.get(to)) // make the underlying kademlia lookup
+    val underlyingChannelTask = kRouter
+      .get(to) // make the underlying kademlia lookup
       .flatMap { record => // use the lookup's address info to obtain an underlying channel...
         debug(s"Routing table lookup returns peer $record. Creating new channel.")
         underlyingPeerGroup.client(record.messagingAddress)

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/XorOrdering.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/XorOrdering.scala
@@ -23,21 +23,9 @@ class XorOrdering(val base: BitVector) extends Ordering[BitVector] {
 }
 
 class XorNodeOrdering[A](val base: BitVector) extends Ordering[NodeRecord[A]] {
+  private val xorIdOrdering = new XorOrdering(base)
 
-  override def compare(lhs: NodeRecord[A], rhs: NodeRecord[A]): Int = {
-    if (lhs.id.length != base.length || rhs.id.length != base.length)
-      throw new IllegalArgumentException(
-        s"Unmatched bit lengths for bit vectors in XorOrdering. (base, lhs, rhs) = ($base, $lhs, $rhs)"
-      )
-    val lb = Xor.d(lhs.id, base)
-    val rb = Xor.d(rhs.id, base)
-    if (lb < rb)
-      -1
-    else if (lb > rb)
-      1
-    else
-      0
-  }
+  override def compare(lhs: NodeRecord[A], rhs: NodeRecord[A]): Int = xorIdOrdering.compare(lhs.id, rhs.id)
 }
 
 class XorOrder[A](val base: BitVector) extends Order[NodeRecord[A]] {

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
@@ -10,6 +10,7 @@ import io.iohk.scalanet.peergroup.{InMemoryPeerGroup, PeerGroup}
 import io.iohk.scalanet.peergroup.kademlia.Generators.aRandomNodeRecord
 import io.iohk.scalanet.peergroup.kademlia.KPeerGroupSpec.withTwoPeerGroups
 import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import monix.eval.Task
 import monix.execution.Scheduler
 import org.mockito.Mockito.when
 import org.scalatest.FlatSpec
@@ -17,8 +18,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar._
 import org.scalatest.concurrent.ScalaFutures._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class KPeerGroupSpec extends FlatSpec {
@@ -92,7 +92,7 @@ object KPeerGroupSpec {
     val kRouter = mock[KRouter[String]]
     val kRouterConfig = KRouter.Config[String](nodeRecord, Set.empty)
     peers.foreach(
-      peerRecord => when(kRouter.get(peerRecord.id)).thenReturn(Future(peerRecord))
+      peerRecord => when(kRouter.get(peerRecord.id)).thenReturn(Task(peerRecord))
     )
     when(kRouter.config).thenReturn(kRouterConfig)
     kRouter


### PR DESCRIPTION
Pr improving various parts of KRouter. Things done:
- Make `nodeRecordIndex` atomic reference. It was `var` updated possibly from multiple threads, which sometimes led to loss of updates
- Get rid of `ConcurrentSubject`. Its main use case is to feed data from non functional parts of system to `Observable` but here `KNetwork` exposes nice interface based on `Task` and `Observable` so it is not needed.  
- Remove blocking constructor, and expose effectful apply methods: 
`startRouterWithServerSeq` and `startRouterWithServerPar`
- Remove not needed `implicit Scheduler` from `KRouter` and KNetwork`
- Make lookup process stacksafe by using stacksafe effect type `Task` and by threading all recursion through flatmap
- Add finishing condition to lookup process described in paper - `queried and recieved responses from k closest nodes`
- Add nodes to kbucket only when receiving message from them.
- Add more tests examining lookup process


