### PR TITLE
[PM-854] Implement cleaning up closed channels

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -15,7 +15,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.7"
 
-  def publishVersion = "0.1-SNAPSHOT"
+  def publishVersion = "0.1.1-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -205,6 +205,9 @@ object PeerGroup {
   class ChannelSetupException[A](val to: A, val cause: Throwable)
       extends RuntimeException(s"Error establishing channel to $to.", cause)
 
+  class ChannelAlreadyClosedException[A](val to: A, val from: A)
+      extends RuntimeException(s"Channel from $from, to $to has already been closed")
+
   class ChannelBrokenException[A](val to: A, val cause: Throwable)
       extends RuntimeException(s"Channel broken to $to.", cause)
 

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
@@ -1,6 +1,8 @@
 package io.iohk.scalanet.peergroup
 
-import org.scalatest.FlatSpec
+import java.net.InetSocketAddress
+
+import org.scalatest.{EitherValues, FlatSpec}
 import org.scalatest.Matchers._
 import io.iohk.scalanet.NetUtils._
 
@@ -10,15 +12,18 @@ import io.iohk.decco.BufferInstantiator.global.HeapByteBuffer
 import io.iohk.decco.Codec
 import io.iohk.scalanet.NetUtils
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
-import monix.execution.Scheduler.Implicits.global
 import org.scalatest.concurrent.ScalaFutures._
-import io.iohk.scalanet.peergroup.PeerGroup.MessageMTUException
+import io.iohk.scalanet.peergroup.PeerGroup.{ChannelAlreadyClosedException, MessageMTUException}
 import io.iohk.scalanet.peergroup.StandardTestPack._
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.execution.schedulers.TestScheduler
 import org.scalatest.RecoverMethods._
 
 import scala.concurrent.Await
 
-class UDPPeerGroupSpec extends FlatSpec {
+class UDPPeerGroupSpec extends FlatSpec with EitherValues {
+  implicit val scheduler = Scheduler.fixedPool("test", 16)
 
   implicit val patienceConfig = PatienceConfig(5 seconds)
 
@@ -65,6 +70,179 @@ class UDPPeerGroupSpec extends FlatSpec {
       Await.result(pg2.initialize().runToFuture, 10 seconds)
     }
     pg1.shutdown().runToFuture.futureValue
+  }
+
+  it should "clean up closed channels in background" in {
+    import UDPPeerGroupSpecUtils._
+    val messageFromClients = "Hello server"
+    val randomNonExistingPeer = InetMultiAddress(aRandomAddress())
+    (for {
+      pg1 <- initUdpPeerGroup()
+      pg1Channel <- pg1.client(randomNonExistingPeer)
+      _ <- pg1Channel.sendMessage(messageFromClients)
+      _ <- pg1Channel.close()
+      _ = testScheduler.tick(pg1.config.cleanUpInitialDelay)
+    } yield {
+      pg1.activeChannels.size() shouldEqual 0
+    }).runSyncUnsafe()
+  }
+
+  it should "echo request from clients received from several channels sequentially" in {
+    import UDPPeerGroupSpecUtils._
+    val messageFromClients = "Hello server"
+    (for {
+      pg1 <- initUdpPeerGroup()
+      pg2 <- initUdpPeerGroup()
+      pg3 <- initUdpPeerGroup()
+      _ <- echoServer(pg2).startAndForget
+      response <- requestResponse(pg1, pg2.processAddress, messageFromClients, 2 seconds)
+      response1 <- requestResponse(pg3, pg2.processAddress, messageFromClients, 2 seconds)
+      numOfServerChannelsAfter2Requests = pg2.activeChannels.size()
+      response2 <- requestResponse(pg1, pg2.processAddress, messageFromClients, 2 seconds)
+      response3 <- requestResponse(pg3, pg2.processAddress, messageFromClients, 2 seconds)
+      numOfServerChannelsAfter4Requests = pg2.activeChannels.size()
+      _ = testScheduler.tick(pg2.config.cleanUpInitialDelay)
+      numOfServerChannelsAfterCleanup = pg2.activeChannels.size()
+      numOfClient1ChannelsAfterCleanup = pg1.activeChannels.size()
+      numOfClient2ChannelsAfterCleanup = pg3.activeChannels.size()
+    } yield {
+      response shouldEqual messageFromClients
+      response1 shouldEqual messageFromClients
+      response2 shouldEqual messageFromClients
+      response3 shouldEqual messageFromClients
+      numOfServerChannelsAfter2Requests shouldEqual 2
+      numOfServerChannelsAfter4Requests shouldEqual 4
+      numOfServerChannelsAfterCleanup shouldEqual 0
+      numOfClient1ChannelsAfterCleanup shouldEqual 0
+      numOfClient2ChannelsAfterCleanup shouldEqual 0
+    }).runSyncUnsafe()
+  }
+
+  it should "echo request from several clients received from several channels in parallel" in {
+    import UDPPeerGroupSpecUtils._
+    val messageFromClients = "Hello server"
+
+    (for {
+      result <- Task.parZip4(
+        initUdpPeerGroup(),
+        initUdpPeerGroup(),
+        initUdpPeerGroup(),
+        initUdpPeerGroup()
+      )
+      (pg1, pg2, pg3, pg4) = result
+      _ <- echoServer(pg4).startAndForget
+      responses <- Task.parZip3(
+        requestResponse(pg1, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg2, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg3, pg4.processAddress, messageFromClients, 2 seconds)
+      )
+      numOfServerChannelsAfter1Round = pg4.activeChannels.size()
+      (pg1Response, pg2Response, pg3Response) = responses
+      _ <- Task.parZip3(
+        requestResponse(pg1, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg2, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg3, pg4.processAddress, messageFromClients, 2 seconds)
+      )
+      numOfServerChannelsAfter2Round = pg4.activeChannels.size()
+      _ = testScheduler.tick(pg4.config.cleanUpInitialDelay)
+      numOfServerChannelsAfterCleanUp = pg4.activeChannels.size()
+      responses1 <- Task.parZip3(
+        requestResponse(pg1, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg2, pg4.processAddress, messageFromClients, 2 seconds),
+        requestResponse(pg3, pg4.processAddress, messageFromClients, 2 seconds)
+      )
+      (pg1Response1, pg2Response1, pg3Response1) = responses1
+      numOfServerChannelsAfter3Round = pg4.activeChannels.size()
+      _ = testScheduler.tick(pg4.config.cleanUpPeriod)
+      numOfServerChannelsAfter2CleanUp = pg4.activeChannels.size()
+
+    } yield {
+      pg1Response shouldEqual messageFromClients
+      pg2Response shouldEqual messageFromClients
+      pg3Response shouldEqual messageFromClients
+      numOfServerChannelsAfter1Round shouldEqual 3
+      numOfServerChannelsAfter2Round shouldEqual 6
+      numOfServerChannelsAfterCleanUp shouldEqual 0
+      pg1Response1 shouldEqual messageFromClients
+      pg2Response1 shouldEqual messageFromClients
+      pg3Response1 shouldEqual messageFromClients
+      numOfServerChannelsAfter3Round shouldEqual 3
+      numOfServerChannelsAfter2CleanUp shouldEqual 0
+    }).runSyncUnsafe()
+  }
+
+  it should "inform user when trying to send message from already closed channel" in {
+    import UDPPeerGroupSpecUtils._
+    val messageFromClients = "Hello server"
+    val randomNonExistingPeer = InetMultiAddress(aRandomAddress())
+
+    (for {
+      pg1 <- initUdpPeerGroup()
+      pg1Channel <- pg1.client(randomNonExistingPeer)
+      _ <- pg1Channel.sendMessage(messageFromClients)
+      _ <- pg1Channel.close()
+      result <- pg1Channel.sendMessage(messageFromClients).attempt
+    } yield {
+      result.left.value shouldBe a[ChannelAlreadyClosedException[_]]
+    }).runSyncUnsafe()
+  }
+
+}
+
+object UDPPeerGroupSpecUtils {
+  val testScheduler = TestScheduler()
+  def requestResponse(
+      peerGroup: PeerGroup[InetMultiAddress, String],
+      to: InetMultiAddress,
+      message: String,
+      requestTimeout: FiniteDuration
+  ): Task[String] = {
+    peerGroup
+      .client(to)
+      .bracket { clientChannel =>
+        sendRequest(message, clientChannel, requestTimeout)
+      } { clientChannel =>
+        clientChannel.close()
+      }
+  }
+
+  def sendRequest(
+      message: String,
+      clientChannel: Channel[InetMultiAddress, String],
+      requestTimeout: FiniteDuration
+  ): Task[String] = {
+    for {
+      _ <- clientChannel.sendMessage(message).timeout(requestTimeout)
+      response <- clientChannel.in.refCount.headL
+        .timeout(requestTimeout)
+    } yield response
+  }
+
+  def echoServer(peerGroup: PeerGroup[InetMultiAddress, String])(implicit s: Scheduler) = {
+    // echo server which closes every incoming channel after response
+    peerGroup
+      .server()
+      .refCount
+      .collectChannelCreated
+      .mergeMap { channel =>
+        channel.in.refCount.map(request => (channel, request))
+      }
+      .foreachL {
+        case (channel, msg) =>
+          Task
+            .eval(channel)
+            .bracket(ch => ch.sendMessage(msg)) { ch =>
+              ch.close()
+            }
+            .runAsyncAndForget
+      }
+  }
+
+  def initUdpPeerGroup(
+      address: InetSocketAddress = aRandomAddress()
+  )(implicit s: Scheduler): Task[UDPPeerGroup[String]] = {
+    val pg = new UDPPeerGroup[String](UDPPeerGroup.Config(address), cleanupScheduler = testScheduler)
+    pg.initialize().map(_ => pg)
   }
 
 }


### PR DESCRIPTION
Till now created channels were added indefinitly to activeChannels map. This could lead to at least to potential problems:
- Exhaustion of resources i.e oom
- Exhaustion od dynamically selected client addresses

This pr tries to fix up this situation. General rules are:
- Library never deletes channels from activeChannels map or closes channels by iteslf. It is entirely in hand of the user of the library.
- Once closed channel can never be open again. 
- Closed channels are cleared from  activeChannels map, by background thread in frequency configured by user.
- Sending message through closed channel is considered to be user error.
- There is slight difference in handling client/server channels on netty side. Client channels are created per 'connection' , so they could be closed also on netty side. On server side, there is actually one server channel so it cannot be closed as this would be equivalent of closing whole server.

