### PR TITLE
[PM-1028] Simple kademlia refresh process

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,6 @@ import coursier.maven.MavenRepository
 import mill.scalalib.{PublishModule, ScalaModule}
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:0.4.1`
-import mill.contrib.scoverage.ScoverageModule
 
 // ScoverageModule creates bug when using custom repositories:
 // https://github.com/lihaoyi/mill/issues/620

--- a/build.sc
+++ b/build.sc
@@ -15,7 +15,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.7"
 
-  def publishVersion = "0.1.1-SNAPSHOT"
+  def publishVersion = "0.1.2-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KBuckets.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KBuckets.scala
@@ -6,9 +6,11 @@ import java.util.Random
 import scodec.bits.BitVector
 
 /**
-  * Skeletal kbucket implementation.
   *
   * @param baseId the nodes own id.
+  * @param clock clock required to keep track of last usage of id in particular bucket
+  * @param buckets list of buckets, each bucket is sorted form least recently seen node id at head and most recently seen
+  *                at the tail
   */
 class KBuckets private (
     val baseId: BitVector,

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KBuckets.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KBuckets.scala
@@ -1,6 +1,7 @@
 package io.iohk.scalanet.peergroup.kademlia
 
 import java.time.Clock
+import java.util.Random
 
 import scodec.bits.BitVector
 
@@ -9,7 +10,11 @@ import scodec.bits.BitVector
   *
   * @param baseId the nodes own id.
   */
-class KBuckets private (val baseId: BitVector, val clock: Clock, val buckets: IndexedSeq[TimeSet[BitVector]]) {
+class KBuckets private (
+    val baseId: BitVector,
+    val clock: Clock,
+    val buckets: IndexedSeq[TimeSet[BitVector]]
+) {
 
   def this(baseId: BitVector, clock: Clock) =
     this(baseId, clock, IndexedSeq.fill(baseId.length.toInt)(TimeSet[BitVector](clock)))
@@ -170,5 +175,11 @@ class KBuckets private (val baseId: BitVector, val clock: Clock, val buckets: In
     } else {
       this
     }
+  }
+}
+
+object KBuckets {
+  def generateRandomId(length: Long, rnd: Random): BitVector = {
+    BitVector.bits(Range.Long(0, length, 1).map(_ => rnd.nextBoolean()))
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -410,6 +410,16 @@ class KRouter[A](
 
 object KRouter {
   import scala.concurrent.duration._
+
+  /**
+    * @param nodeRecord the node own data
+    * @param knownPeers node initial known peers i.e bootstrap nodes
+    * @param alpha kademlia concurrency parameter, determines how many FindNodes request will be sent concurrently to peers.
+    * @param k kademlia neighbours parameter, how many closest neighbours should be returned in response to FindNodes request
+    *          also bucket maximum size. In paper mentioned as replication parameter
+    * @param serverBufferSize maximum size of server messages buffer
+    * @param refreshRate frequency of kademlia refresh procedure
+    */
   case class Config[A](
       nodeRecord: NodeRecord[A],
       knownPeers: Set[NodeRecord[A]],

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KBucketsSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KBucketsSpec.scala
@@ -1,5 +1,6 @@
 package io.iohk.scalanet.peergroup.kademlia
 
+import java.security.SecureRandom
 import java.time.Clock
 
 import io.iohk.scalanet.peergroup.kademlia.Generators._
@@ -21,6 +22,14 @@ class KBucketsSpec extends FlatSpec {
 
     kBuckets.contains(id) shouldBe true
     kBuckets.closestNodes(id, Int.MaxValue) shouldBe List(id)
+  }
+
+  they should "generate random id of the same length as base id" in {
+    val baseId = aRandomBitVector()
+
+    val randomId = KBuckets.generateRandomId(baseId.length, new SecureRandom())
+
+    baseId.length shouldEqual randomId.length
   }
 
   they should "retrieve any node added via put" in forAll(genBitVector()) { v =>


### PR DESCRIPTION
Implements kademlia refresh process in simple version used in other p2p implementation i.e performing lookup for random targets:
https://github.com/ethereum/go-ethereum/blob/fa538ee7ed04b1a5e101938d64805d3fcd0eb697/p2p/discover/table.go#L298
https://github.com/status-im/nim-eth/blob/e6164996c8e1ce1a33c17250935fc985b9120830/eth/p2p/discovery.nim#L284