### PR TITLE
[PM-1035] Parallelism level can now be configured by the user in Config class

### DIFF
--- a/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
@@ -199,7 +199,8 @@ object KademliaIntegrationSpec {
       alpha: Int = 3,
       k: Int = 20,
       serverBufferSize: Int = 2000,
-      refreshRate: FiniteDuration = 15.minutes
+      refreshRate: FiniteDuration = 15.minutes,
+      parallelism: Int = 4
   )
 
   val defaultConfig = TestNodeKademliaConfig()
@@ -224,7 +225,8 @@ object KademliaIntegrationSpec {
       alpha = testConfig.alpha,
       k = testConfig.k,
       serverBufferSize = testConfig.serverBufferSize,
-      refreshRate = testConfig.refreshRate
+      refreshRate = testConfig.refreshRate,
+      parallelism = testConfig.parallelism
     )
 
     for {

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -48,9 +48,8 @@ class KRouter[A](
       })
   }
 
-  // TODO[PM-1035]: parallelism should be configured by library user
   private val responseTaskConsumer =
-    Consumer.foreachParallelTask[(KRequest[A], Option[KResponse[A]] => Task[Unit])](parallelism = 4) {
+    Consumer.foreachParallelTask[(KRequest[A], Option[KResponse[A]] => Task[Unit])](config.parallelism) {
       case (FindNodes(uuid, nodeRecord, targetNodeId), responseHandler) =>
         debug(
           s"Received request FindNodes(${nodeRecord.id.toHex}, $nodeRecord, ${targetNodeId.toHex})"
@@ -419,6 +418,7 @@ object KRouter {
     *          also bucket maximum size. In paper mentioned as replication parameter
     * @param serverBufferSize maximum size of server messages buffer
     * @param refreshRate frequency of kademlia refresh procedure
+    * @param parallelism level of parallelism the request will be processed
     */
   case class Config[A](
       nodeRecord: NodeRecord[A],
@@ -426,7 +426,8 @@ object KRouter {
       alpha: Int = 3,
       k: Int = 20,
       serverBufferSize: Int = 2000,
-      refreshRate: FiniteDuration = 15.minutes
+      refreshRate: FiniteDuration = 15.minutes,
+      parallelism:Int = 4
   )
 
   private[scalanet] def getIndex[A](config: Config[A], clock: Clock): NodeRecordIndex[A] = {

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -418,7 +418,7 @@ object KRouter {
     *          also bucket maximum size. In paper mentioned as replication parameter
     * @param serverBufferSize maximum size of server messages buffer
     * @param refreshRate frequency of kademlia refresh procedure
-    * @param parallelism level of parallelism the request will be processed
+    * @param maximum number of thread that will be created for handling incoming request
     */
   case class Config[A](
       nodeRecord: NodeRecord[A],
@@ -427,7 +427,7 @@ object KRouter {
       k: Int = 20,
       serverBufferSize: Int = 2000,
       refreshRate: FiniteDuration = 15.minutes,
-      parallelism:Int = 4
+      parallelism: Int = 4
   )
 
   private[scalanet] def getIndex[A](config: Config[A], clock: Clock): NodeRecordIndex[A] = {


### PR DESCRIPTION
The subclass KRouter.Config has now a new variable called "parallelism", set for default in 4. This variable is used in the initialization of KRouter, for indicate the Consumer who handle the incoming request the maximum number of thread it should create for this purpose