### PR TITLE
Nodes records have now authentication. Adapted to Ethereum Node record scheme.

### DIFF
--- a/scalanet/src/io/iohk/scalanet/codec/StreamObjects.scala
+++ b/scalanet/src/io/iohk/scalanet/codec/StreamObjects.scala
@@ -1,0 +1,487 @@
+package io.iohk.scalanet.codec
+
+import java.math.BigInteger
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.ByteBuffer
+import java.util.UUID
+
+import io.iohk.decco.BufferInstantiator.global.HeapByteBuffer
+import io.iohk.decco.Codec.{DecodeResult, Failure}
+import io.iohk.decco.{BufferInstantiator, CodecContract}
+import io.iohk.scalanet.peergroup.InetMultiAddress
+import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.peergroup.kademlia.{KMessage, KRouter}
+import scodec.bits.BitVector
+
+import scala.annotation.tailrec
+
+object IntegerStreamCodec extends StreamCodec[Int]{
+  override def streamDecode[B](source: B)(implicit bi: BufferInstantiator[B]): Seq[Int] = {
+    val buff = bi.asByteBuffer(source)
+    @tailrec
+    def aux(start:Int,acum:List[Int]): List[Int] ={
+      if(start + 4 < buff.capacity()) {
+        val n = this.decode(start,buff).right.get
+        aux(start + 4, n :: acum)
+      }else acum
+    }
+    aux(0,Nil)
+  }
+
+  override def cleanSlate: StreamCodec[Int] = IntegerStreamCodec
+
+  override def encode[B](t: Int)(implicit bi: BufferInstantiator[B]): B = {
+    val buff = ByteBuffer.allocate(4)
+    buff.putInt(t)
+    bi.asB(buff)
+  }
+
+  override def decode[B](start: Int, source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, Int] = {
+    val buff = bi.asByteBuffer(source)
+    if(buff.capacity() < start+4) Left(Failure)
+    else Right(buff.getInt(start))
+  }
+
+  override def decode[B](source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, Int] = this.decode(0,source)
+}
+
+object IntegerCodecContract extends CodecContract[Int]{
+  override def size(t: Int): Int = 4
+
+  override def encodeImpl(t: Int, start: Int, destination: ByteBuffer): Unit = {
+    destination.putInt(start,t)
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[Int]] = {
+    if(start+4 > source.capacity()) Left(Failure)
+    else Right(new DecodeResult[Int](source.getInt(start),start+4))
+  }
+}
+
+
+object CharacterStreamCodec extends StreamCodec[Char]{
+  override def streamDecode[B](source: B)(implicit bi: BufferInstantiator[B]): Seq[Char] = {
+    val buff = bi.asByteBuffer(source)
+    @tailrec
+    def aux(act:Int,acum:List[Char]): List[Char] ={
+      if(act>=buff.capacity()) acum
+      else aux(act+1,buff.get(act).toChar :: acum)
+    }
+    aux(0,Nil)
+  }
+
+  override def cleanSlate: StreamCodec[Char] = CharacterStreamCodec
+
+  override def encode[B](t: Char)(implicit bi: BufferInstantiator[B]): B = {
+    val buff = ByteBuffer.allocate(1)
+    buff.putChar(t)
+    bi.asB(buff)
+  }
+
+  override def decode[B](start: Int, source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, Char] = {
+    val buff = bi.asByteBuffer(source)
+    if(start>buff.capacity()) Left(Failure)
+    else Right(buff.getChar(start))
+  }
+
+  override def decode[B](source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, Char] = decode(0,source)
+}
+
+object ArrayBufferInstantiator extends BufferInstantiator[Array[Byte]] {
+  override def instantiateByteBuffer(size: Int): ByteBuffer = ByteBuffer.allocate(size)
+
+  override def asB(byteBuffer: ByteBuffer): Array[Byte] = {
+    val res = new Array[Byte](byteBuffer.capacity())
+    for(i <- 0 until byteBuffer.capacity()){
+      res(i) = byteBuffer.get(i)
+    }
+    res
+  }
+
+  override def asByteBuffer(b: Array[Byte]): ByteBuffer = {
+    val res = instantiateByteBuffer(b.length)
+    for(i <- 0 until b.length){
+      res.put(i,b(i))
+    }
+    res
+  }
+}
+
+class SeqCodecContract[A](codecContract: CodecContract[A]) extends CodecContract[Seq[A]]{
+
+  override def size(t: Seq[A]): Int = t.foldLeft(4)((rec,x) => codecContract.size(x) + rec)
+
+  override def encodeImpl(t: Seq[A], start: Int, destination: ByteBuffer): Unit = {
+    IntegerCodecContract.encodeImpl(t.size,start,destination)
+    var ind = start + 4
+    for(el <- t ){
+      codecContract.encodeImpl(el,ind,destination)
+      ind = ind + codecContract.size(el)
+    }
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[Seq[A]]] = {
+    IntegerCodecContract.decodeImpl(start,source) match {
+      case Left(f) => Left(f)
+      case Right(_dec) => {
+        @tailrec
+        def aux(pos:Int,number:Int,acum:List[A]): Either[Failure, DecodeResult[List[A]]] = {
+          if(number>=_dec.decoded) Right(new DecodeResult[List[A]](acum.reverse,pos))
+          else{
+            val dec = codecContract.decodeImpl(pos,source)
+            dec match {
+              case Left(f) => Left(f)
+              case Right(v) => aux(v.nextIndex,number+1,v.decoded :: acum)
+            }
+          }
+        }
+        aux(_dec.nextIndex,0,Nil)
+      }
+    }
+  }
+}
+
+
+class EitherCodecContract[A,B](a:CodecContract[A],b:CodecContract[B]) extends CodecContract[Either[A,B]]{
+  override def size(t: Either[A, B]): Int = t match{
+    case Left(elemA) => a.size(elemA) + 1
+    case Right(elemB) => b.size(elemB) + 1
+  }
+
+  override def encodeImpl(t: Either[A, B], start: Int, destination: ByteBuffer): Unit = t match{
+    case Left(elemA) =>{
+      destination.put(start,0)
+      a.encodeImpl(elemA,start+1,destination)
+    }
+    case Right(elemB) => {
+      destination.put(start,1)
+      b.encodeImpl(elemB,start+1,destination)
+    }
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[Either[A, B]]] = {
+    if(source.get(start)==0){
+      val rec = a.decodeImpl(start+1,source)
+      rec match {
+        case Left(f) => Left(f)
+        case Right(dec) => Right( new DecodeResult[Either[A, B]](Left(dec.decoded),dec.nextIndex))
+      }
+    }else if(source.get(start)==1){
+      val rec = b.decodeImpl(start+1,source)
+      rec match {
+        case Left(f) => Left(f)
+        case Right(dec) => Right( new DecodeResult[Either[A, B]](Right(dec.decoded),dec.nextIndex))
+      }
+    }else{
+      Left(Failure)
+    }
+  }
+}
+
+object ByteArrayCodecContract extends CodecContract[Array[Byte]] {
+  override def size(t: Array[Byte]): Int = t.length + 4
+
+  override def encodeImpl(t: Array[Byte], start: Int, destination: ByteBuffer): Unit = {
+    IntegerCodecContract.encodeImpl(t.length,start,destination)
+    t.foldLeft(start+4)((pos,elem) => {destination.put(pos,elem);pos+1} )
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[Array[Byte]]] = {
+    IntegerCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(size) => {
+        val res = new Array[Byte](size.decoded)
+        if(source.capacity() < size.nextIndex+size.decoded) {return Left(Failure)}
+        for(i <- 0 until size.decoded){
+          res(i) = source.get(i+size.nextIndex)
+        }
+        Right(new DecodeResult[Array[Byte]](res,size.decoded+size.nextIndex))
+      }
+    }
+  }
+}
+
+object InetAddressCodecContract extends CodecContract[InetMultiAddress]{
+  override def size(t: InetMultiAddress): Int = 4 + ByteArrayCodecContract.size(t.inetSocketAddress.getAddress.getAddress)
+
+  override def encodeImpl(t: InetMultiAddress, start: Int, destination: ByteBuffer): Unit = {
+    IntegerCodecContract.encodeImpl(t.inetSocketAddress.getPort,start,destination)
+    val addr = t.inetSocketAddress.getAddress.getAddress
+    ByteArrayCodecContract.encodeImpl(addr,start+4,destination)
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[InetMultiAddress]] = {
+    IntegerCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(port) => {
+        ByteArrayCodecContract.decodeImpl(port.nextIndex,source) match{
+          case Left(f) => Left(f)
+          case Right(addr) => {
+            Right(new DecodeResult[InetMultiAddress](InetMultiAddress(new InetSocketAddress(InetAddress.getByAddress(addr.decoded),port.decoded)),addr.nextIndex))
+          }
+        }
+      }
+    }
+  }
+}
+
+
+class NodeRecordCodeContract[A](codecContract: CodecContract[A]) extends CodecContract[KRouter.NodeRecord[A]]{
+  override def size(t: KRouter.NodeRecord[A]): Int = ByteArrayCodecContract.size(t.id.toByteArray) + codecContract.size(t.messagingAddress) + codecContract.size(t.routingAddress)+16+BigIntegerCodecContract.size(t.sign._1) + BigIntegerCodecContract.size(t.sign._2)
+
+  override def encodeImpl(t: KRouter.NodeRecord[A], start: Int, destination: ByteBuffer): Unit = {
+    val idArray = t.id.toByteArray
+    ByteArrayCodecContract.encodeImpl(idArray,start,destination)
+    codecContract.encodeImpl(t.messagingAddress,start + ByteArrayCodecContract.size(idArray),destination)
+    codecContract.encodeImpl(t.routingAddress,start + ByteArrayCodecContract.size(idArray) + codecContract.size(t.messagingAddress),destination)
+    LongerCodecContract.encodeImpl(t.sec_number,start + ByteArrayCodecContract.size(idArray) + codecContract.size(t.messagingAddress) + codecContract.size(t.routingAddress),destination)
+    BigIntegerCodecContract.encodeImpl(t.sign._1,start + ByteArrayCodecContract.size(idArray) + codecContract.size(t.messagingAddress) + codecContract.size(t.routingAddress)+8,destination)
+    BigIntegerCodecContract.encodeImpl(t.sign._2,start + ByteArrayCodecContract.size(idArray) + codecContract.size(t.messagingAddress) + codecContract.size(t.routingAddress)+8+BigIntegerCodecContract.size(t.sign._1),destination)
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[KRouter.NodeRecord[A]]] = {
+    ByteArrayCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(idArray) =>{
+        codecContract.decodeImpl(idArray.nextIndex,source) match{
+          case Left(f) => Left(f)
+          case Right(messagingAddress) => {
+            codecContract.decodeImpl(messagingAddress.nextIndex,source) match{
+              case Left(f) => Left(f)
+              case Right(routingAddress) => LongerCodecContract.decodeImpl(routingAddress.nextIndex,source) match{
+                case Left(f) => Left(f)
+                case Right(sec_number) => BigIntegerCodecContract.decodeImpl(sec_number.nextIndex,source) match{
+                  case Left(f) => Left(f)
+                  case Right(signed_1) => BigIntegerCodecContract.decodeImpl(signed_1.nextIndex,source) match{
+                    case Left(f) => Left(f)
+                    case Right(signed_2) => Right (new DecodeResult[KRouter.NodeRecord[A]](KRouter.NodeRecord[A](BitVector(idArray.decoded),routingAddress.decoded,messagingAddress.decoded,sec_number.decoded,(signed_1.decoded,signed_2.decoded)),signed_2.nextIndex))
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+object BigIntegerCodecContract extends CodecContract[BigInteger] {
+  override def size(t: BigInteger): Int = t.toByteArray.length
+
+  override def encodeImpl(t: BigInteger, start: Int, destination: ByteBuffer): Unit = ByteArrayCodecContract.encodeImpl(t.toByteArray,start,destination)
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[BigInteger]] = {
+    ByteArrayCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(d) => Right(new DecodeResult[BigInteger](new BigInteger(d.decoded),d.nextIndex))
+    }
+  }
+}
+
+object LongerCodecContract extends CodecContract[Long] {
+  override def size(t: Long): Int = 8
+
+  override def encodeImpl(t: Long, start: Int, destination: ByteBuffer): Unit = destination.putLong(start,t)
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[Long]] ={
+    if(source.capacity() < start + 8) Left(Failure)
+    else Right(new DecodeResult[Long](source.getLong(start),start+8))
+  }
+}
+
+class KMessageCodecContract[A](codecContract: CodecContract[KRouter.NodeRecord[A]]) extends CodecContract[KMessage[A]]{
+  val nodesSeq = new SeqCodecContract[KRouter.NodeRecord[A]](codecContract)
+  override def size(t: KMessage[A]): Int = t match{
+    case KRequest.FindNodes(_,nodeRecord,targetNodeId) => 1 +  16 + codecContract.size(nodeRecord) + ByteArrayCodecContract.size((targetNodeId.toByteArray))
+    case KRequest.Ping(_,nodeRecord) =>  1 + 16 + codecContract.size(nodeRecord)
+    case KResponse.Pong(_,nodeRecord) =>  1 +16 + codecContract.size(nodeRecord)
+    case KResponse.Nodes(_,nodeRecord,nodes) => 1 + 16 + codecContract.size(nodeRecord) + nodesSeq.size(nodes)
+  }
+
+  override def encodeImpl(t: KMessage[A], start: Int, destination: ByteBuffer): Unit = t match{
+    case KRequest.FindNodes(id,nodeRecord,targetNodeId) => {
+      destination.put(start,0)
+      LongerCodecContract.encodeImpl(id.getLeastSignificantBits,start+1,destination)
+      LongerCodecContract.encodeImpl(id.getMostSignificantBits,start+9,destination)
+      codecContract.encodeImpl(nodeRecord,start+17,destination)
+      ByteArrayCodecContract.encodeImpl(targetNodeId.toByteArray,start+17+codecContract.size(nodeRecord),destination)
+    }
+    case KRequest.Ping(id,nodeRecord) => {
+      destination.put(start,1)
+      LongerCodecContract.encodeImpl(id.getLeastSignificantBits,start+1,destination)
+      LongerCodecContract.encodeImpl(id.getMostSignificantBits,start+1+8,destination)
+      codecContract.encodeImpl(nodeRecord,start+17,destination)
+    }
+    case KResponse.Pong(id,nodeRecord) =>{
+      destination.put(start,2)
+      LongerCodecContract.encodeImpl(id.getLeastSignificantBits,start+1,destination)
+      LongerCodecContract.encodeImpl(id.getMostSignificantBits,start+1+8,destination)
+      codecContract.encodeImpl(nodeRecord,start+17,destination)
+    }
+    case KResponse.Nodes(id,nodeRecord,nodes) => {
+      destination.put(start,3)
+      LongerCodecContract.encodeImpl(id.getLeastSignificantBits,start+1,destination)
+      LongerCodecContract.encodeImpl(id.getMostSignificantBits,start+1+8,destination)
+      codecContract.encodeImpl(nodeRecord,start+17,destination)
+      nodesSeq.encodeImpl(nodes,start+17+codecContract.size(nodeRecord),destination)
+    }
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[KMessage[A]]] = {
+    if(source.get(start)==0.toByte){
+      LongerCodecContract.decodeImpl(start+1,source) match {
+        case Left(f) => Left(f)
+        case Right(leastSignificantBits) => {
+          LongerCodecContract.decodeImpl(leastSignificantBits.nextIndex,source) match{
+            case Left(f) => Left(f)
+            case Right(mostSignificantBits) => {
+              codecContract.decodeImpl(mostSignificantBits.nextIndex,source) match{
+                case Left(f) => Left(f)
+                case Right(nodeRecord) => ByteArrayCodecContract.decodeImpl(nodeRecord.nextIndex,source) match{
+                  case Left(f) => Left(f)
+                  case Right(targetNodeId) => Right(new DecodeResult[KMessage[A]](KRequest.FindNodes(new UUID(mostSignificantBits.decoded,leastSignificantBits.decoded) ,nodeRecord.decoded,BitVector(targetNodeId.decoded) ),targetNodeId.nextIndex))
+                }
+              }
+            }
+          }
+        }
+      }
+    }else if(source.get(start)==1.toByte){
+      LongerCodecContract.decodeImpl(start+1,source) match {
+        case Left(f) => Left(f)
+        case Right(leastSignificantBits) => {
+          LongerCodecContract.decodeImpl(leastSignificantBits.nextIndex,source) match{
+            case Left(f) => Left(f)
+            case Right(mostSignificantBits) => {
+              codecContract.decodeImpl(mostSignificantBits.nextIndex,source) match{
+                case Left(f) => Left(f)
+                case Right(nodeRecord) => Right (new DecodeResult[KMessage[A]](KRequest.Ping(new UUID(mostSignificantBits.decoded,leastSignificantBits.decoded),nodeRecord.decoded),nodeRecord.nextIndex))
+              }
+            }
+          }
+        }
+      }
+    }else if(source.get(start)==2.toByte){
+      LongerCodecContract.decodeImpl(start+1,source) match {
+        case Left(f) => Left(f)
+        case Right(leastSignificantBits) => {
+          LongerCodecContract.decodeImpl(leastSignificantBits.nextIndex,source) match{
+            case Left(f) => Left(f)
+            case Right(mostSignificantBits) => {
+              codecContract.decodeImpl(mostSignificantBits.nextIndex,source) match{
+                case Left(f) => Left(f)
+                case Right(nodeRecord) => Right (new DecodeResult[KMessage[A]](KResponse.Pong(new UUID(mostSignificantBits.decoded,leastSignificantBits.decoded),nodeRecord.decoded),nodeRecord.nextIndex))
+              }
+            }
+          }
+        }
+      }
+    }else if(source.get(start)==3.toByte){
+      LongerCodecContract.decodeImpl(start+1,source) match {
+        case Left(f) => Left(f)
+        case Right(leastSignificantBits) => {
+          LongerCodecContract.decodeImpl(leastSignificantBits.nextIndex,source) match{
+            case Left(f) => Left(f)
+            case Right(mostSignificantBits) => {
+              codecContract.decodeImpl(mostSignificantBits.nextIndex,source) match{
+                case Left(f) => Left(f)
+                case Right(nodeRecord) => nodesSeq.decodeImpl(nodeRecord.nextIndex,source) match{
+                  case Left(f) => Left(f)
+                  case Right(nodes) => Right(new DecodeResult[KMessage[A]](KResponse.Nodes(new UUID(mostSignificantBits.decoded,leastSignificantBits.decoded),nodeRecord.decoded,nodes.decoded ) ,nodes.nextIndex ) )
+                }
+              }
+            }
+          }
+        }
+      }
+    }else Left(Failure)
+  }
+}
+
+class StreamCodecFromContract[A](codecContract: CodecContract[A]) extends StreamCodec[A] {
+
+  override def streamDecode[B](source: B)(implicit bi: BufferInstantiator[B]): Seq[A] = {
+    val buff = bi.asByteBuffer(source)
+    def aux(pos:Int): Stream[A] = {
+      if(pos >= buff.capacity()) Stream()
+      else{
+        codecContract.decodeImpl(pos,buff) match{
+          case Left(_) => throw new RuntimeException("PROBLEM DECODING")
+          case Right(dec) => {dec.decoded #:: aux(dec.nextIndex)}
+        }
+      }
+    }
+    aux(0)
+  }
+
+  override def cleanSlate: StreamCodec[A] = this
+
+  override def encode[B](t: A)(implicit bi: BufferInstantiator[B]): B = {
+    val res = ByteBuffer.allocate(codecContract.size(t))
+    codecContract.encodeImpl(t,0,res)
+    bi.asB(res)
+  }
+
+  override def decode[B](start: Int, source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, A] = {
+    codecContract.decodeImpl(start,bi.asByteBuffer(source)) match{
+      case Left(f) => Left(f)
+      case Right(res) => Right(res.decoded)
+    }
+  }
+
+  override def decode[B](source: B)(implicit bi: BufferInstantiator[B]): Either[Failure, A] = decode(0,source)
+}
+
+object InetSocketCodecContract extends CodecContract[InetSocketAddress] {
+  override def size(t: InetSocketAddress): Int = InetAddressCodecContract.size(InetMultiAddress(t))
+
+  override def encodeImpl(t: InetSocketAddress, start: Int, destination: ByteBuffer): Unit = InetAddressCodecContract.encodeImpl(InetMultiAddress(t),start,destination)
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[InetSocketAddress]] = InetAddressCodecContract.decodeImpl(start,source) match{
+    case Left(f) => Left(f)
+    case Right(dec) => Right(new DecodeResult[InetSocketAddress](dec.decoded.inetSocketAddress,dec.nextIndex))}
+}
+
+object UUIDCodecContract extends CodecContract[UUID] {
+  override def size(t: UUID): Int = 16
+
+  override def encodeImpl(t: UUID, start: Int, destination: ByteBuffer): Unit = {
+    LongerCodecContract.encodeImpl(t.getMostSignificantBits,start,destination)
+    LongerCodecContract.encodeImpl(t.getLeastSignificantBits,start+8,destination)
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[UUID]] = {
+    LongerCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(mostSignificant) => LongerCodecContract.decodeImpl(mostSignificant.nextIndex,source) match{
+        case Left(f) => Left(f)
+        case Right(leastSignificant) => Right(new DecodeResult[UUID](new UUID(mostSignificant.decoded,leastSignificant.decoded),leastSignificant.nextIndex))
+      }
+    }
+  }
+}
+
+object StringCodecContract extends CodecContract[String] {
+  override def size(t: String): Int = 4 + t.length + 1
+
+  override def encodeImpl(t: String, start: Int, destination: ByteBuffer): Unit = {
+    IntegerCodecContract.encodeImpl(t.length,start,destination)
+    for(i <- 0 until t.length){
+      destination.putChar(i+start+4,t.charAt(i))
+    }
+  }
+
+  override def decodeImpl(start: Int, source: ByteBuffer): Either[Failure, DecodeResult[String]] = {
+    IntegerCodecContract.decodeImpl(start,source) match{
+      case Left(f) => Left(f)
+      case Right(length) => {
+        val res = new Array[Char](length.decoded)
+        for(i <- 0 until length.decoded){
+          res(i) = source.getChar(i+length.nextIndex)
+        }
+        Right(new DecodeResult[String] (new String(res),length.decoded+length.nextIndex))
+      }
+    }
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/crypto/package.scala
+++ b/scalanet/src/io/iohk/scalanet/crypto/package.scala
@@ -1,0 +1,58 @@
+package io.iohk.scalanet
+
+import java.math.BigInteger
+import java.security.SecureRandom
+
+import org.spongycastle.asn1.sec.SECNamedCurves
+import org.spongycastle.asn1.x9.X9ECParameters
+import org.spongycastle.crypto.AsymmetricCipherKeyPair
+import org.spongycastle.crypto.digests.SHA256Digest
+import org.spongycastle.crypto.generators.ECKeyPairGenerator
+import org.spongycastle.crypto.params.{ECDomainParameters, ECKeyGenerationParameters, ECPrivateKeyParameters, ECPublicKeyParameters}
+import org.spongycastle.crypto.signers.{ECDSASigner, HMacDSAKCalculator}
+
+package  object crypto {
+
+  val curveParams: X9ECParameters = SECNamedCurves.getByName("secp256k1")
+  val curve: ECDomainParameters = new ECDomainParameters(curveParams.getCurve, curveParams.getG, curveParams.getN, curveParams.getH)
+
+  def recuperateEncodedKey(key:Array[Byte] ): ECPublicKeyParameters ={
+    new ECPublicKeyParameters(curve.getCurve.decodePoint(key),curve)
+  }
+  def keyPairToByteArrays(keyPair: AsymmetricCipherKeyPair): (Array[Byte], Array[Byte]) = {
+    val prvKey = keyPair.getPrivate.asInstanceOf[ECPrivateKeyParameters].getD.toByteArray
+    val pubKey = keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail
+    (prvKey, pubKey)
+  }
+
+  def encodeKey(key: ECPublicKeyParameters):Array[Byte] = {
+   key.getQ.getEncoded(true)
+  }
+
+  def generateKeyPair(secureRandom: SecureRandom): (ECPrivateKeyParameters,ECPublicKeyParameters) = {
+    val generator = new ECKeyPairGenerator
+    generator.init(new ECKeyGenerationParameters(curve, secureRandom))
+    val res = generator.generateKeyPair()
+    (res.getPrivate.asInstanceOf[ECPrivateKeyParameters],res.getPublic.asInstanceOf[ECPublicKeyParameters])
+  }
+
+  private def canonicalise(s: BigInteger): BigInteger = {
+    val halfCurveOrder: BigInteger = curveParams.getN.shiftRight(1)
+    if (s.compareTo(halfCurveOrder) > 0) curve.getN.subtract(s)
+    else s
+  }
+
+  def sign(data:Array[Byte],privateKey: ECPrivateKeyParameters):(BigInteger,BigInteger) = {
+    val signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest))
+    signer.init(true, privateKey)
+    val components = signer.generateSignature(data)
+    (components(0),canonicalise(components(1)))
+  }
+
+  def verify(data:Array[Byte],r:BigInteger,s:BigInteger,publicKey:ECPublicKeyParameters): Boolean = {
+    val signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest))
+    signer.init(false, publicKey)
+    signer.verifySignature(data,r,s)
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -1,11 +1,16 @@
 package io.iohk.scalanet.peergroup.kademlia
 
+import java.math.BigInteger
+import java.nio.ByteBuffer
 import java.security.SecureRandom
 import java.time.Clock
 import java.util.{Random, UUID}
 
 import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
+import io.iohk.decco.BufferInstantiator.global.HeapByteBuffer
+import io.iohk.decco.Codec
+import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
 import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
 import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
@@ -14,19 +19,23 @@ import io.iohk.scalanet.peergroup.kademlia.KRouter.{Config, NodeRecord}
 import monix.eval.Task
 import monix.reactive.{Consumer, Observable, OverflowStrategy}
 import org.slf4j.LoggerFactory
+import org.spongycastle.crypto.params.ECPrivateKeyParameters
 import scodec.bits.BitVector
+import io.iohk.scalanet.crypto
 
 class KRouter[A](
     val config: Config[A],
     val network: KNetwork[A],
     private val routerState: Ref[Task, NodeRecordIndex[A]],
+    private val privateKey:ECPrivateKeyParameters,
     val clock: Clock = Clock.systemUTC(),
     val uuidSource: () => UUID = () => UUID.randomUUID(),
     val rnd: Random = new SecureRandom()
-) {
+)(implicit codec:Codec[A]) {
 
   private val log = LoggerFactory.getLogger(getClass)
 
+  var actualNodeRecord = config.nodeRecord
   /**
     * Start refresh cycle i.e periodically performs lookup for random node id
     *
@@ -43,8 +52,11 @@ class KRouter[A](
   private def startRefreshCycle(): Task[Unit] = {
     Observable
       .intervalWithFixedDelay(config.refreshRate, config.refreshRate)
-      .consumeWith(Consumer.foreachTask { _ =>
-        lookup(KBuckets.generateRandomId(config.nodeRecord.id.length, rnd)).map(_ => ())
+      .consumeWith(Consumer.foreachTask { _ => {
+          val newNodeRecord = NodeRecord.create(actualNodeRecord.id,actualNodeRecord.routingAddress,actualNodeRecord.messagingAddress,actualNodeRecord.sec_number+1,privateKey)
+          actualNodeRecord = newNodeRecord
+          lookup(KBuckets.generateRandomId(config.nodeRecord.id.length, rnd)).map(_ => ())
+        }
       })
   }
 
@@ -59,7 +71,7 @@ class KRouter[A](
         for {
           state <- routerState.get
           closestNodes = state.kBuckets.closestNodes(targetNodeId, config.k).map(state.nodeRecords(_))
-          response = Nodes(uuid, config.nodeRecord, closestNodes)
+          response = Nodes(uuid, actualNodeRecord, closestNodes)
           _ <- add(nodeRecord).startAndForget
           responseTask <- responseHandler(Some(response))
         } yield responseTask
@@ -68,7 +80,7 @@ class KRouter[A](
         debug(
           s"Received request Ping(${nodeRecord.id.toHex}, $nodeRecord)"
         )
-        val response = Pong(uuid, config.nodeRecord)
+        val response = Pong(uuid, actualNodeRecord)
         for {
           _ <- add(nodeRecord).startAndForget
           responseTask <- responseHandler(Some(response))
@@ -129,29 +141,33 @@ class KRouter[A](
     routerState.get.map(_.nodeRecords)
   }
 
-  def ping(recToPing: NodeRecord[A]): Task[Boolean] = {
+  def ping(recToPing: NodeRecord[A]): Task[Option[NodeRecord[A]]] = {
     network
-      .ping(recToPing, Ping(uuidSource(), config.nodeRecord))
-      .map(_ => true)
-      .onErrorHandle(_ => false)
-
+      .ping(recToPing, Ping(uuidSource(), actualNodeRecord))
+      .map(x => Some(x.nodeRecord))
+      .onErrorHandle(_ => None)
   }
 
   def add(nodeRecord: NodeRecord[A]): Task[Unit] = {
     info(s"Handling potential addition of candidate (${nodeRecord.id.toHex}, $nodeRecord)")
-    for {
-      toPing <- routerState.modify { current =>
-        val (_, bucket) = current.kBuckets.getBucket(nodeRecord.id)
-        if (bucket.size < config.k) {
-          (current.addNodeRecord(nodeRecord), None)
-        } else {
-          // the bucket is full, not update it but ping least recently seen node (i.e. the one at the head) to see what to do
-          val nodeToPing = current.nodeRecords(bucket.head)
-          (current, Some(nodeToPing))
-        }
-      }
-      result <- pingAndUpdateState(toPing, nodeRecord)
-    } yield result
+    if(!NodeRecord.verify[A](nodeRecord)) Task.eval()
+    else {
+      getLocally(nodeRecord.id).flatMap(previewsRegisterNodeRecord => if (previewsRegisterNodeRecord.isDefined && previewsRegisterNodeRecord.get.sec_number > nodeRecord.sec_number) Task.eval() else
+        for {
+          toPing <- routerState.modify { current =>
+            val (_, bucket) = current.kBuckets.getBucket(nodeRecord.id)
+            if (bucket.size < config.k) {
+              (current.addNodeRecord(nodeRecord), None)
+            } else {
+              // the bucket is full, not update it but ping least recently seen node (i.e. the one at the head) to see what to do
+              val nodeToPing = current.nodeRecords(bucket.head)
+              (current, Some(nodeToPing))
+            }
+          }
+          result <- pingAndUpdateState(toPing, nodeRecord)
+        } yield result
+      )
+    }
   }
 
   private def pingAndUpdateState(recordToPing: Option[NodeRecord[A]], nodeRecord: NodeRecord[A]): Task[Unit] = {
@@ -161,9 +177,10 @@ class KRouter[A](
         for {
           pingResult <- ping(nodeToPing)
           _ <- routerState.update { current =>
-            if (pingResult) {
+            if (pingResult.isDefined && pingResult.get.sec_number >= nodeToPing.sec_number) {
               // if it does respond, it is moved to the tail and the other node record discarded.
-              current.touchNodeRecord(nodeToPing)
+              if(nodeToPing.sec_number.equals(pingResult.get.sec_number)) current.touchNodeRecord(nodeToPing)
+              else current.replaceNodeRecord(nodeToPing,pingResult.get)
             } else {
               // if that node fails to respond, it is evicted from the bucket and the other node inserted (at the tail)
               current.replaceNodeRecord(nodeToPing, nodeRecord)
@@ -171,7 +188,7 @@ class KRouter[A](
           }
 
           _ <- Task.eval {
-            if (pingResult) {
+            if (pingResult.isDefined) {
               info(
                 s"Moving ${nodeToPing.id} to head of bucket. Discarding (${nodeRecord.id.toHex}, $nodeRecord) as routing table candidate."
               )
@@ -220,7 +237,7 @@ class KRouter[A](
 
       val findNodesRequest = FindNodes(
         requestId = requestId,
-        nodeRecord = config.nodeRecord,
+        nodeRecord = actualNodeRecord,
         targetNodeId = targetNodeId
       )
 
@@ -447,14 +464,15 @@ object KRouter {
   def startRouterWithServerSeq[A](
       config: Config[A],
       network: KNetwork[A],
+      privateKey:ECPrivateKeyParameters,
       clock: Clock = Clock.systemUTC(),
       uuidSource: () => UUID = () => UUID.randomUUID()
-  ): Task[KRouter[A]] = {
+  )(implicit codec: Codec[A]): Task[KRouter[A]] = {
     for {
       state <- Ref.of[Task, NodeRecordIndex[A]](
         getIndex(config, clock)
       )
-      router <- Task.now(new KRouter(config, network, state, clock, uuidSource))
+      router <- Task.now(new KRouter(config, network, state,privateKey, clock, uuidSource))
       _ <- router.enroll()
       _ <- router.startServerHandling().startAndForget
       _ <- router.startRefreshCycle().startAndForget
@@ -476,15 +494,16 @@ object KRouter {
   def startRouterWithServerPar[A](
       config: Config[A],
       network: KNetwork[A],
+      privateKey:ECPrivateKeyParameters,
       clock: Clock = Clock.systemUTC(),
       uuidSource: () => UUID = () => UUID.randomUUID()
-  ): Task[KRouter[A]] = {
+  )(implicit codec:Codec[A]) : Task[KRouter[A]] = {
     Ref
       .of[Task, NodeRecordIndex[A]](
         getIndex(config, clock)
       )
       .flatMap { state =>
-        Task.now(new KRouter(config, network, state, clock, uuidSource)).flatMap { router =>
+        Task.now(new KRouter(config, network, state,privateKey, clock, uuidSource)).flatMap { router =>
           Task.parMap3(
             router.enroll(),
             router.startServerHandling().startAndForget,
@@ -500,9 +519,25 @@ object KRouter {
   // sequence number (why)
   // compressed public key (why)
   // TODO understand what these things do, which we need an implement.
-  case class NodeRecord[A](id: BitVector, routingAddress: A, messagingAddress: A) {
+  case class NodeRecord[A](id: BitVector, routingAddress: A, messagingAddress: A,sec_number:Long,sign:(BigInteger,BigInteger)) {
     override def toString: String =
-      s"NodeRecord(id = ${id.toHex}, routingAddress = $routingAddress, messagingAddress = $messagingAddress)"
+      s"NodeRecord(sec_number = ${sec_number}, id = ${id.toHex}, routingAddress = $routingAddress, messagingAddress = $messagingAddress)"
+  }
+
+  object NodeRecord{
+    def create[A](id: BitVector, routingAddress: A, messagingAddress: A,sec_number:Long,key:ECPrivateKeyParameters)(implicit codec: Codec[A]):NodeRecord[A] = {
+      val encodedUUID = ByteBuffer.allocate(8)
+      encodedUUID.putLong(0,sec_number)
+      val encoded = id.toByteArray ++ codec.encode[ByteBuffer](routingAddress).array() ++ codec.encode[ByteBuffer](routingAddress).array() ++ encodedUUID.array()
+      val sign = crypto.sign(encoded,key)
+      NodeRecord[A](id,routingAddress,messagingAddress,sec_number,sign)
+    }
+    def verify[A](n:NodeRecord[A])(implicit codec: Codec[A]):Boolean = {
+      val encodedUUID = ByteBuffer.allocate(8)
+      encodedUUID.putLong(0,n.sec_number)
+      val encoded = n.id.toByteArray ++ codec.encode[ByteBuffer](n.routingAddress).array() ++ codec.encode[ByteBuffer](n.routingAddress).array() ++ encodedUUID.array()
+      crypto.verify(encoded,n.sign._1,n.sign._2,crypto.recuperateEncodedKey(n.id.toByteArray))
+    }
   }
 
   private[scalanet] object KRouterInternals {

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KPeerGroupSpec.scala
@@ -3,6 +3,7 @@ package io.iohk.scalanet.peergroup.kademlia
 import java.nio.ByteBuffer
 
 import io.iohk.decco.{BufferInstantiator, Codec}
+import io.iohk.scalanet.codec._
 import io.iohk.scalanet.peergroup.InMemoryPeerGroup.Network
 import io.iohk.scalanet.peergroup.PeerGroup.createOrThrow
 import io.iohk.scalanet.peergroup.StandardTestPack.messagingTest
@@ -22,7 +23,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class KPeerGroupSpec extends FlatSpec {
-
+  implicit val codec:Codec[Either[NodeRecord[String],String]] = new StreamCodecFromContract[Either[NodeRecord[String], String]](new EitherCodecContract[NodeRecord[String],String](new NodeRecordCodeContract(StringCodecContract),StringCodecContract))
   implicit val patienceConfig: ScalaFutures.PatienceConfig = PatienceConfig(
     1 second
   )


### PR DESCRIPTION
- NodeRecord subclass have now a sign. KRouter's node's id is a 33 byte public key
- Add package crypto
- Add spongycastle to dependencies
- Add StreamObject file 

One of the Kademelia implementation TODO indicates Kademlia Node Records, the message object that binds a Kademlia ID with his direction in the sub-net, should be signed, using the model of Ethereum Node Records. This model specify the secp256k1 encryption system must be used.

In this implementation a node’s Kademlia ID is its encoded secp256k1 public key. With this, we solved the problem of binding a public key with a direction on the web, because if a node changes its public key, it changes its direction.

The node record has now a sign of the rest of the node record information, using SHA-256 to make the hash. When a node receives a node record, verify if the sign is valid, and if it’s not, the node record will not add.

This system is important because without any identification, everyone can send a fake node record binding an ID of another node with an IP that he controls. Later, it is possible to mount a malicious node on the web with this ID, who sends fake information causing the web doesn’t trust in the ID and the original node will be beaned.

Also, without signed a user can create malicious nodes with IDs similar to a target node and monopolizes its connection with the net. But if the ID must be a public key that correspond to a private key, its difficult generate a pair of keys with this properties.

Additionally, a sequence number has been added. This number increment himself everytime the node refresh, and should increment manually if the node shutdown and later is online again with other IP.

If there are two record nodes with the same vector ID, the system only register the node record with the higher sequence number. This prevent a node to register obsolete information.

PROBLEMS:

- Kademlia specification says the Node’s ID has 160 bits. In the implementation, this can be different, because nodes only check that a node ID has the same length of its own ID. So, all nodes of the web must have IDs with the same length, that can be or not of 160 bits. With this change, the length of nodes ID must be of 264 bits.
 
- You can’t change your public key without losing your identity. In the blockchain case this is not very important, because there are no funds associated with this. A node ID is only an identification, and a node can change it without important repercussions. If a node is hacked and its private key is stolen, the node must change his ID.