### PR TITLE
[PM-1284] Implementation of dynamic tls peer group based on libp2p specs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -12,7 +12,7 @@ import $ivy.`com.lihaoyi::mill-contrib-buildinfo:0.4.1`
 //object scalanet extends ScalaModule with PublishModule with ScoverageModule {
 object scalanet extends ScalaModule with PublishModule {
 
-  def scalaVersion = "2.12.7"
+  def scalaVersion = "2.12.10"
 
   def publishVersion = "0.1.5-SNAPSHOT"
 
@@ -48,7 +48,10 @@ object scalanet extends ScalaModule with PublishModule {
     ivy"org.eclipse.californium:element-connector:2.0.0-M15",
     ivy"org.scodec::scodec-bits:1.1.12",
     ivy"org.scodec::scodec-core:1.11.4",
-    ivy"org.scala-lang.modules::scala-parser-combinators:1.1.2"
+    ivy"org.scala-lang.modules::scala-parser-combinators:1.1.2",
+    ivy"org.bouncycastle:bcprov-jdk15on:1.64",
+    ivy"org.bouncycastle:bcpkix-jdk15on:1.64",
+    ivy"org.bouncycastle:bctls-jdk15on:1.64"
   )
 
   def pomSettings = PomSettings(
@@ -88,7 +91,7 @@ object scalanet extends ScalaModule with PublishModule {
   object it extends TestModule
 
   object examples extends ScalaModule {
-    override def scalaVersion = "2.12.7"
+    override def scalaVersion = "2.12.10"
 
     override def scalacOptions = scalanet.scalacOptions
 

--- a/build.sc
+++ b/build.sc
@@ -41,6 +41,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   override def ivyDeps = Agg(
     ivy"io.monix::monix:3.0.0",
+    ivy"com.github.nscala-time::nscala-time:2.22.0",
     ivy"com.chuusai::shapeless:2.3.3",
     ivy"org.slf4j:slf4j-api:1.7.25",
     ivy"io.netty:netty-all:4.1.31.Final",

--- a/build.sc
+++ b/build.sc
@@ -14,7 +14,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.10"
 
-  def publishVersion = "0.1.5-SNAPSHOT"
+  def publishVersion = "0.1.6-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/src/io/iohk/scalanet/crypto/CryptoUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/crypto/CryptoUtils.scala
@@ -26,6 +26,10 @@ import scodec.bits.BitVector
 import scala.util.Try
 
 private[scalanet] object CryptoUtils {
+
+  /**
+    * Elliptic Curve Groups(ECDHE) recommended by TLS 1.3
+    */
   sealed abstract class SupportedCurves(val name: String)
   case object Secp256r1 extends SupportedCurves("secp256r1")
   case object Secp384r1 extends SupportedCurves("secp384r1")
@@ -81,7 +85,7 @@ private[scalanet] object CryptoUtils {
     new KeyPair(keyFac.generatePublic(spkiKeySpec), keyFac.generatePrivate(pkcs8KeySpec))
   }
 
-  def getKeyFromBytes(bytes: Array[Byte]) = {
+  def getKeyFromBytes(bytes: Array[Byte]): Try[PublicKey] = Try {
     val ecPoint = curve.getCurve.decodePoint(bytes)
     val spec = new ECParameterSpec(curveParams.getCurve, curveParams.getG, curveParams.getN)
     val pubKeySpec = new ECPublicKeySpec(ecPoint, spec)

--- a/scalanet/src/io/iohk/scalanet/crypto/CryptoUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/crypto/CryptoUtils.scala
@@ -1,0 +1,127 @@
+package io.iohk.scalanet.crypto
+
+import java.math.BigInteger
+import java.security._
+import java.security.cert.X509Certificate
+import java.security.spec.{ECGenParameterSpec, PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.util.Date
+
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.Extension
+import org.bouncycastle.asn1.sec.SECNamedCurves
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.asn1.x9.X9ECParameters
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.bouncycastle.crypto.generators.ECKeyPairGenerator
+import org.bouncycastle.crypto.params.{ECDomainParameters, ECKeyGenerationParameters}
+import org.bouncycastle.crypto.util.{PrivateKeyInfoFactory, SubjectPublicKeyInfoFactory}
+import org.bouncycastle.jce.interfaces.ECPublicKey
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.jce.spec.{ECParameterSpec, ECPublicKeySpec}
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import scodec.bits.BitVector
+
+import scala.util.Try
+
+private[scalanet] object CryptoUtils {
+  sealed abstract class SupportedCurves(val name: String)
+  case object Secp256r1 extends SupportedCurves("secp256r1")
+  case object Secp384r1 extends SupportedCurves("secp384r1")
+  case object Secp521r1 extends SupportedCurves("secp521r1")
+
+  val curveName = "secp256k1"
+
+  val PROVIDER = new BouncyCastleProvider()
+
+  val curveParams: X9ECParameters = SECNamedCurves.getByName(curveName)
+
+  val curve: ECDomainParameters =
+    new ECDomainParameters(curveParams.getCurve, curveParams.getG, curveParams.getN, curveParams.getH)
+
+  def generateKeyPair(secureRandom: SecureRandom): AsymmetricCipherKeyPair = {
+    val generator = new ECKeyPairGenerator
+    generator.init(new ECKeyGenerationParameters(curve, secureRandom))
+    generator.generateKeyPair()
+  }
+
+  def genEcKeyPair(secureRandom: SecureRandom, curveName: String): KeyPair = {
+    val ecSpec = new ECGenParameterSpec(curveName)
+    val g = KeyPairGenerator.getInstance("EC", PROVIDER)
+    g.initialize(ecSpec, secureRandom)
+    g.generateKeyPair();
+  }
+
+  def genTlsSupportedKeyPair(secureRandom: SecureRandom, curveName: SupportedCurves): KeyPair = {
+    genEcKeyPair(secureRandom, curveName.name)
+  }
+
+  def signEcdsa(data: Array[Byte], privateKey: PrivateKey, secureRandom: SecureRandom): Array[Byte] = {
+    val ecdsaSign = Signature.getInstance("SHA256withECDSA", PROVIDER)
+    ecdsaSign.initSign(privateKey, secureRandom)
+    ecdsaSign.update(data);
+    ecdsaSign.sign();
+  }
+
+  def verifyEcdsa(data: Array[Byte], sig: Array[Byte], publicKey: java.security.PublicKey): Boolean =
+    Try {
+      val ecdsaVerify = Signature.getInstance("SHA256withECDSA", PROVIDER)
+      ecdsaVerify.initVerify(publicKey)
+      ecdsaVerify.update(data)
+      ecdsaVerify.verify(sig)
+    }.fold(_ => false, result => result)
+
+  def convertBcToJceKeyPair(bcKeyPair: AsymmetricCipherKeyPair): KeyPair = {
+    val pkcs8Encoded = PrivateKeyInfoFactory.createPrivateKeyInfo(bcKeyPair.getPrivate).getEncoded()
+    val pkcs8KeySpec = new PKCS8EncodedKeySpec(pkcs8Encoded)
+    val spkiEncoded = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(bcKeyPair.getPublic).getEncoded()
+    val spkiKeySpec = new X509EncodedKeySpec(spkiEncoded)
+    val keyFac = KeyFactory.getInstance("EC", PROVIDER)
+    new KeyPair(keyFac.generatePublic(spkiKeySpec), keyFac.generatePrivate(pkcs8KeySpec))
+  }
+
+  def getKeyFromBytes(bytes: Array[Byte]) = {
+    val ecPoint = curve.getCurve.decodePoint(bytes)
+    val spec = new ECParameterSpec(curveParams.getCurve, curveParams.getG, curveParams.getN)
+    val pubKeySpec = new ECPublicKeySpec(ecPoint, spec)
+    val keyFac = KeyFactory.getInstance("EC", PROVIDER)
+    keyFac.generatePublic(pubKeySpec)
+  }
+
+  def getBouncyCastlePubKey(bytes: Array[Byte], algorithm: String): Try[PublicKey] = Try {
+    val spec = new X509EncodedKeySpec(bytes)
+    val keyFac = KeyFactory.getInstance(algorithm, PROVIDER)
+    keyFac.generatePublic(spec)
+  }
+
+  def getEcPublicKey(publicKey: PublicKey): Try[BitVector] = Try {
+    BitVector(publicKey.asInstanceOf[ECPublicKey].getQ.getEncoded(false))
+  }
+
+  def buildCertificateWithExtensions(
+      connectionKeyPair: KeyPair,
+      random: SecureRandom,
+      extensions: List[Extension],
+      beforeDate: Date,
+      afterDate: Date
+  ): X509Certificate = {
+    val name = "scalanet-tls"
+    val sn = new BigInteger(64, random)
+    val owner = new X500Name("CN=" + name);
+    val sub = SubjectPublicKeyInfo.getInstance(connectionKeyPair.getPublic.getEncoded)
+    val certificateBuilder = new X509v3CertificateBuilder(owner, sn, beforeDate, afterDate, owner, sub)
+
+    extensions.foreach { extension =>
+      certificateBuilder.addExtension(extension.oid, extension.isCritical, extension.value)
+    }
+
+    val signer = new JcaContentSignerBuilder("SHA256WITHECDSA").build(connectionKeyPair.getPrivate);
+
+    val ca = certificateBuilder.build(signer)
+
+    val cert = new JcaX509CertificateConverter().setProvider(PROVIDER).getCertificate(ca)
+
+    cert
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
@@ -47,7 +47,7 @@ case class InetMultiAddress(inetSocketAddress: InetSocketAddress) {
 }
 
 object InetMultiAddress {
-  implicit val adressInst = new Addressable[InetMultiAddress] {
+  implicit val addressableInetMultiAddressInst = new Addressable[InetMultiAddress] {
     override def getAddress(a: InetMultiAddress): InetSocketAddress = a.inetSocketAddress
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
@@ -2,6 +2,14 @@ package io.iohk.scalanet.peergroup
 
 import java.net.{InetAddress, InetSocketAddress}
 
+trait Addressable[A] {
+  def getAddress(a: A): InetSocketAddress
+}
+
+object Addressable {
+  def apply[A](implicit sh: Addressable[A]): Addressable[A] = sh
+}
+
 /**
   * TCP and UDP (and other socket-based protocols) have a problem where addressing and multiplexing are coupled.
   * This means that, in TCP world a single node can have multiple addresses. Even though port numbers are used
@@ -35,5 +43,11 @@ case class InetMultiAddress(inetSocketAddress: InetSocketAddress) {
   override def hashCode(): Int = {
     val state = Seq(inetAddress)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+}
+
+object InetMultiAddress {
+  implicit val adressInst = new Addressable[InetMultiAddress] {
+    override def getAddress(a: InetMultiAddress): InetSocketAddress = a.inetSocketAddress
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -175,7 +175,7 @@ object ReqResponseProtocol {
     val rnd = new SecureRandom()
     val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
     val pg1 =
-      new DynamicTLSPeerGroup[MessageEnvelope[M]](DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd))
+      new DynamicTLSPeerGroup[MessageEnvelope[M]](DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd).get)
     buildProtocol(pg1)
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomTlsValidator.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomTlsValidator.scala
@@ -1,0 +1,102 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import java.security.cert.{CertificateException, X509Certificate}
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+import java.util.Date
+
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKey
+import scodec.bits.BitVector
+
+import scala.util.{Failure, Success, Try}
+
+object CustomTlsValidator {
+  sealed abstract class CertificateError(msg: String) extends CertificateException(msg)
+  case object WrongNumberOfCertificates extends CertificateError("Number of certificates not equal 1")
+  case object WrongCertificateDate extends CertificateError("Certificate is expired or not yet valid")
+  case object NoCertExtension extends CertificateError("Certificate does not have required extension")
+  case object WrongExtensionFormat extends CertificateError("Extension has invalid format")
+  case object WrongExtensionSignature extends CertificateError("Signature on cert extension is invalid")
+  case object SeverIdNotMatchExpected extends CertificateError("Server id do not match expected")
+
+  private def validateServerId(
+      receivedKey: SignedKey,
+      expectedPeerInfo: BitVector
+  ): Either[SeverIdNotMatchExpected.type, Unit] = {
+    Either.cond(receivedKey.publicKey.getNodeId == expectedPeerInfo, (), SeverIdNotMatchExpected)
+  }
+
+  private def validateCertificatesQuantity(
+      certificates: Array[X509Certificate]
+  ): Either[CertificateError, X509Certificate] = {
+    if (certificates.length != 1) {
+      Left(WrongNumberOfCertificates)
+    } else {
+      Right(certificates.head)
+    }
+  }
+
+  private def validateCertificateDate(cert: X509Certificate): Either[CertificateError, Unit] = {
+    val todayUtcDate = Date.from(LocalDateTime.now(Clock.systemUTC()).toInstant(ZoneOffset.UTC))
+    Try(cert.checkValidity(todayUtcDate)) match {
+      case Failure(_) => Left(WrongCertificateDate)
+      case Success(_) => Right(())
+    }
+  }
+
+  private def validateCertificateSignature(
+      signedKey: SignedKey,
+      cert: X509Certificate
+  ): Either[CertificateError, Unit] = {
+    val certificatePublicKey = cert.getPublicKey
+    (for {
+      // Certificate keys have different implementation (sun), to use our other machinery it need to be converted to Bouncy
+      // castle format
+      pubKeyInBcFormat <- CryptoUtils.getBouncyCastlePubKey(
+        certificatePublicKey.getEncoded,
+        certificatePublicKey.getAlgorithm
+      )
+      keyBytes <- CryptoUtils.getEcPublicKey(pubKeyInBcFormat)
+      result <- Try(SignedKey.verifySignature(signedKey, keyBytes))
+    } yield result) match {
+      case Failure(_) => Left(WrongExtensionSignature)
+      case Success(value) =>
+        if (value)
+          Right(())
+        else
+          Left(WrongExtensionSignature)
+    }
+  }
+
+  def validateCertificates(
+      certificates: Array[X509Certificate],
+      connectingTo: Option[BitVector]
+  ): Either[CertificateError, SignedKey] = {
+    for {
+      cert <- validateCertificatesQuantity(certificates)
+      _ <- validateCertificateDate(cert)
+      extension <- validateCertificateExtension(cert, SignedKey.extensionIdentifier)
+      signedKeyExtension <- validateExtension(extension)
+      _ <- validateCertificateSignature(signedKeyExtension, cert)
+      _ <- if (connectingTo.isDefined) validateServerId(signedKeyExtension, connectingTo.get) else Right(())
+    } yield {
+      signedKeyExtension
+    }
+  }
+
+  private def validateCertificateExtension(
+      cert: X509Certificate,
+      extensionId: String
+  ): Either[CertificateError, Array[Byte]] = {
+    val extension = cert.getExtensionValue(extensionId)
+    if (extension == null) {
+      Left(NoCertExtension)
+    } else {
+      Right(extension)
+    }
+  }
+
+  private def validateExtension(extension: Array[Byte]): Either[CertificateError, SignedKey] = {
+    SignedKey.parseAsn1EncodedValue(extension).toEither.left.map(_ => WrongExtensionFormat)
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSExtension.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSExtension.scala
@@ -1,0 +1,216 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import java.security.cert.X509Certificate
+import java.security.{KeyPair, PublicKey, SecureRandom}
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+import java.util.Date
+
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.crypto.CryptoUtils.SupportedCurves
+import org.bouncycastle.asn1._
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve
+import scodec.bits.BitVector
+import scodec.codecs.{Discriminated, Discriminator, ascii, bits, uint8}
+import scodec.{Attempt, Codec, DecodeResult, SizeBound}
+
+import scala.util.{Failure, Success, Try}
+
+sealed trait KeyType {
+  def n: Int
+}
+object KeyType {
+  implicit val d = Discriminated[KeyType, Int](uint8)
+}
+
+case object Secp256k1 extends KeyType {
+  val curveName = "secp256k1"
+  val n = 2
+  implicit val Secp256k1disc = Discriminator[KeyType, Secp256k1.type, Int](n)
+}
+
+private[scalanet] object DynamicTLSExtension {
+  val prefix = "libp2p-tls-handshake:"
+
+  val prefixAsBytes = ascii.encode(prefix).require
+
+  case class ExtensionPublicKey private (keyType: KeyType, encodedPublicKey: PublicKey)
+
+  object ExtensionPublicKey {
+    private val keyCodec = Codec[KeyType]
+
+    val extensionPublicKeyCodec = new Codec[ExtensionPublicKey] {
+      override def encode(value: ExtensionPublicKey): Attempt[BitVector] = {
+        for {
+          key <- keyCodec.encode(value.keyType)
+          public <- value.keyType match {
+            case Secp256k1 => Attempt.fromTry(CryptoUtils.getEcPublicKey(value.encodedPublicKey))
+          }
+        } yield key ++ public
+      }
+
+      override def decode(bits: BitVector): Attempt[DecodeResult[ExtensionPublicKey]] = {
+        for {
+          keyTypeResult <- keyCodec.decode(bits)
+          rest <- keyTypeResult.value match {
+            case Secp256k1 => Attempt.fromTry(Try(CryptoUtils.getKeyFromBytes(keyTypeResult.remainder.toByteArray)))
+          }
+        } yield DecodeResult(new ExtensionPublicKey(keyTypeResult.value, rest), BitVector.empty)
+      }
+
+      override def sizeBound: SizeBound = SizeBound.unknown
+    }
+
+    implicit class ExtensionPublicKeyOps(key: ExtensionPublicKey) {
+      def getNodeId: BitVector = {
+        key.keyType match {
+          case Secp256k1 => CryptoUtils.getEcPublicKey(key.encodedPublicKey).get.drop(8)
+        }
+      }
+    }
+
+    def apply(keyType: KeyType, encodedPublicKey: PublicKey): Try[ExtensionPublicKey] = {
+      keyType match {
+        case Secp256k1 =>
+          for {
+            bouncPubKey <- CryptoUtils.getBouncyCastlePubKey(encodedPublicKey.getEncoded, encodedPublicKey.getAlgorithm)
+            ecpublicKey <- Try(bouncPubKey.asInstanceOf[org.bouncycastle.jce.interfaces.ECPublicKey].getParameters)
+            curve = ecpublicKey.getCurve
+            _ <- if (curve.isInstanceOf[SecP256K1Curve]) Success(())
+            else Failure(new RuntimeException("Key type do not match provided key"))
+          } yield new ExtensionPublicKey(Secp256k1, bouncPubKey)
+      }
+    }
+  }
+
+  case class Extension(oid: ASN1ObjectIdentifier, isCritical: Boolean, value: ASN1Encodable)
+
+  case class SignedKey(publicKey: ExtensionPublicKey, signature: BitVector)
+
+  object SignedKey {
+
+    private case class SignedKeyBytes(publicKey: Array[Byte], signature: Array[Byte])
+
+    val extensionIdentifier = "1.3.6.1.4.1.53594.1.1"
+
+    val signedKeyExtensionIdentifier = new ASN1ObjectIdentifier(extensionIdentifier)
+
+    private def parseAsn1EncodedBytes(bytes: Array[Byte]): Attempt[SignedKeyBytes] = {
+      Attempt.fromTry {
+        Try {
+          val extensionValue = JcaX509ExtensionUtils
+            .parseExtensionValue(bytes)
+            .asInstanceOf[DLSequence]
+          val hostPublicKey = extensionValue.getObjectAt(0).asInstanceOf[DERBitString].getBytes
+          val signature = extensionValue.getObjectAt(1).asInstanceOf[DERBitString].getBytes
+          SignedKeyBytes(hostPublicKey, signature)
+        }
+      }
+    }
+
+    private def toASN1Encodable(signedKey: SignedKey): Attempt[ASN1Encodable] = {
+      for {
+        publicKey <- ExtensionPublicKey.extensionPublicKeyCodec.encode(signedKey.publicKey)
+        signature <- scodec.codecs.bits.encode(signedKey.signature)
+      } yield {
+        val pubKeyAsBitString = new DLBitString(publicKey.toByteArray)
+        val sigAsBitString = new DLBitString(signature.toByteArray)
+        val encVector = new ASN1EncodableVector(2)
+        encVector.add(pubKeyAsBitString)
+        encVector.add(sigAsBitString)
+        new DLSequence(encVector)
+      }
+    }
+
+    private def toCertExtension(signedKey: SignedKey): Attempt[Extension] = {
+      toASN1Encodable(signedKey).map(
+        asEncodable => Extension(signedKeyExtensionIdentifier, isCritical = true, asEncodable)
+      )
+    }
+
+    def parseAsn1EncodedValue(bytes: Array[Byte]): Attempt[SignedKey] = {
+      for {
+        signedKeyBytes <- parseAsn1EncodedBytes(bytes)
+        pub <- ExtensionPublicKey.extensionPublicKeyCodec.decodeValue(BitVector(signedKeyBytes.publicKey))
+        sig <- bits.decodeValue(BitVector(signedKeyBytes.signature))
+      } yield SignedKey(pub, sig)
+    }
+
+    private def buildSignedKey(
+        keyType: KeyType,
+        hostKeyPair: KeyPair,
+        connectionPublicKey: BitVector,
+        secureRandom: SecureRandom
+    ): Attempt[SignedKey] = {
+      val bytesToSign = prefixAsBytes ++ connectionPublicKey
+      val signature = BitVector(CryptoUtils.signEcdsa(bytesToSign.toByteArray, hostKeyPair.getPrivate, secureRandom))
+      Attempt.fromTry(
+        ExtensionPublicKey(keyType, hostKeyPair.getPublic).map(extPublicKey => SignedKey(extPublicKey, signature))
+      )
+    }
+
+    def buildSignedKeyExtension(
+        keyType: KeyType,
+        hostKeyPair: KeyPair,
+        connectionPublicKey: BitVector,
+        secureRandom: SecureRandom
+    ): Attempt[(SignedKey, Extension)] =
+      for {
+        signedKey <- buildSignedKey(keyType, hostKeyPair, connectionPublicKey, secureRandom)
+        encoded <- toCertExtension(signedKey)
+      } yield (signedKey, encoded)
+
+    def verifySignature(signedKey: SignedKey, certPublicKey: BitVector): Boolean = {
+      val bytes = (prefixAsBytes ++ certPublicKey).toByteArray
+      CryptoUtils.verifyEcdsa(bytes, signedKey.signature.toByteArray, signedKey.publicKey.encodedPublicKey)
+    }
+
+  }
+
+  case class SignedKeyExtensionNodeData(
+      calculatedNodeId: BitVector,
+      certWithExtension: X509Certificate,
+      generatedConnectionKey: KeyPair
+  )
+
+  object SignedKeyExtensionNodeData {
+    def apply(
+        hostKeyType: KeyType,
+        hostKeyPair: KeyPair,
+        connectionKeyType: SupportedCurves,
+        secureRandom: SecureRandom
+    ): Try[SignedKeyExtensionNodeData] = {
+      // key must be one from 5.1.1. Supported Elliptic Curves Extension rfc4492, we only support subset which is also
+      // available in tls 1.3 it will ease up migration in the future
+      val connectionKeyPair = CryptoUtils.genTlsSupportedKeyPair(secureRandom, connectionKeyType)
+
+      // safe to call get, as key is generated by us
+      val connectionKeyPairPublicKeyAsBytes = CryptoUtils.getEcPublicKey(connectionKeyPair.getPublic).get
+
+      // Certificate will be valid for next 100 years, the same value is used in libp2p go implementation
+      val today = LocalDateTime.now(Clock.systemUTC())
+      val beforeDate = Date.from(today.minusMonths(1).toInstant(ZoneOffset.UTC))
+      val afterDate = Date.from(today.plusYears(100).toInstant(ZoneOffset.UTC))
+
+      SignedKey
+        .buildSignedKeyExtension(Secp256k1, hostKeyPair, connectionKeyPairPublicKeyAsBytes, secureRandom)
+        .map {
+          case (signedKey, signedKeyExtension) =>
+            val nodeId = signedKey.publicKey.getNodeId
+
+            val cert =
+              CryptoUtils.buildCertificateWithExtensions(
+                connectionKeyPair,
+                secureRandom,
+                List(signedKeyExtension),
+                beforeDate,
+                afterDate
+              )
+
+            new SignedKeyExtensionNodeData(nodeId, cert, connectionKeyPair)
+        }
+        .toTry
+    }
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -1,8 +1,6 @@
 package io.iohk.scalanet.peergroup.dynamictls
 
-import java.io.IOException
-import java.net.{ConnectException, InetSocketAddress}
-import java.nio.channels.ClosedChannelException
+import java.net.InetSocketAddress
 import java.security._
 import java.security.cert.X509Certificate
 
@@ -12,26 +10,19 @@ import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
 import io.iohk.scalanet.monix_subject.ConnectableSubject
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
-import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
-import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, HandshakeException, ServerEvent, TerminalPeerGroup}
+import io.iohk.scalanet.peergroup.PeerGroup.{ServerEvent, TerminalPeerGroup}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKeyExtensionNodeData
-import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{
-  ClientChannelImpl,
-  Config,
-  PeerInfo,
-  ServerChannelBuilder
-}
-import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupUtils.{SSLContextForClient, SSLContextForSever}
-import io.iohk.scalanet.peergroup.{Addressable, Channel, InetMultiAddress, PeerGroup}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{Config, PeerInfo}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupInternals.{ClientChannelImpl, ServerChannelBuilder}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupUtils.{SSLContextForClient, SSLContextForServer}
+import io.iohk.scalanet.peergroup.{Addressable, Channel, InetMultiAddress}
 import io.netty.bootstrap.{Bootstrap, ServerBootstrap}
-import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.channel._
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.{NioServerSocketChannel, NioSocketChannel}
 import io.netty.handler.logging.{LogLevel, LoggingHandler}
-import io.netty.handler.ssl.{SslContext, SslHandshakeCompletionEvent}
-import javax.net.ssl._
+import io.netty.handler.ssl.SslContext
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.observables.ConnectableObservable
@@ -39,8 +30,6 @@ import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.slf4j.LoggerFactory
 import scodec.bits.BitVector
 
-import scala.collection.JavaConverters._
-import scala.concurrent.Promise
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -61,7 +50,7 @@ class DynamicTLSPeerGroup[M](val config: Config)(
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForSever, config)
+  private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForServer, config)
 
   private val serverSubject = ConnectableSubject[ServerEvent[PeerInfo, M]]()
 
@@ -124,7 +113,7 @@ class DynamicTLSPeerGroup[M](val config: Config)(
 object DynamicTLSPeerGroup {
   case class PeerInfo(id: BitVector, address: InetMultiAddress)
   object PeerInfo {
-    implicit val peerInInst = new Addressable[PeerInfo] {
+    implicit val peerInfoAddressable = new Addressable[PeerInfo] {
       override def getAddress(a: PeerInfo): InetSocketAddress = a.address.inetSocketAddress
     }
   }
@@ -163,232 +152,6 @@ object DynamicTLSPeerGroup {
     ): Try[Config] = {
       val convertedKeyPair = CryptoUtils.convertBcToJceKeyPair(hostKeyPair)
       Config(bindAddress, keyType, convertedKeyPair, secureRandom)
-    }
-  }
-
-  private class MessageNotifier[M](
-      val messageSubject: ConnectableSubject[M],
-      codec: StreamCodec[M]
-  ) extends ChannelInboundHandlerAdapter {
-
-    private val log = LoggerFactory.getLogger(getClass)
-
-    override def channelInactive(channelHandlerContext: ChannelHandlerContext): Unit =
-      messageSubject.onComplete()
-
-    override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
-      val byteBuf = msg.asInstanceOf[ByteBuf]
-      try {
-        log.info(
-          s"Processing inbound message from remote address ${ctx.channel().remoteAddress()} " +
-            s"to local address ${ctx.channel().localAddress()}"
-        )
-        codec
-          .streamDecode(BitVector(byteBuf.nioBuffer()))
-          .foreach(message => messageSubject.onNext(message))
-      } finally {
-        byteBuf.release()
-      }
-    }
-
-    override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-      // swallow netty's default logging of the stack trace.
-    }
-  }
-
-  private class ClientChannelImpl[M](
-      peerInfo: PeerInfo,
-      clientBootstrap: Bootstrap,
-      sslClientCtx: SslContext,
-      codec: StreamCodec[M]
-  )(implicit scheduler: Scheduler)
-      extends Channel[PeerInfo, M] {
-
-    private val log = LoggerFactory.getLogger(getClass)
-
-    val to: PeerInfo = peerInfo
-
-    private val activation = Promise[ChannelHandlerContext]()
-    private val activationF = activation.future
-
-    private val deactivation = Promise[Unit]()
-    private val deactivationF = deactivation.future
-
-    private val messageSubject = ConnectableSubject[M]()
-
-    private val bootstrap: Bootstrap = clientBootstrap
-      .clone()
-      .handler(new ChannelInitializer[SocketChannel]() {
-        def initChannel(ch: SocketChannel): Unit = {
-          val pipeline = ch.pipeline()
-          val sslHandler = sslClientCtx.newHandler(ch.alloc())
-
-          pipeline
-            .addLast("ssl", sslHandler) //This needs to be first
-            .addLast(new ChannelInboundHandlerAdapter() {
-
-              override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-                deactivation.success(())
-              }
-
-              override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
-                evt match {
-                  case e: SslHandshakeCompletionEvent =>
-                    log.info(
-                      s"Ssl Handshake client channel from ${ctx.channel().localAddress()} " +
-                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
-                    )
-                    if (e.isSuccess)
-                      activation.success(ctx)
-                    else {
-                      activation.failure(e.cause())
-                    }
-
-                  case _ =>
-                    log.info(
-                      s"User Event client channel from ${ctx.channel().localAddress()} " +
-                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id}"
-                    )
-                }
-              }
-            })
-            .addLast(new MessageNotifier[M](messageSubject, codec))
-        }
-      })
-
-    private def mapException(t: Throwable): Throwable = t match {
-      case _: ClosedChannelException =>
-        new PeerGroup.ChannelBrokenException(to, t)
-      case _: ConnectException =>
-        new PeerGroup.ChannelSetupException(to, t)
-      case _: SSLKeyException =>
-        new PeerGroup.HandshakeException(to, t)
-      case _: SSLHandshakeException =>
-        new PeerGroup.HandshakeException(to, t)
-      case _: SSLException =>
-        new PeerGroup.HandshakeException(to, t)
-      case _ =>
-        t
-    }
-
-    def initialize: Task[ClientChannelImpl[M]] = {
-      toTask(bootstrap.connect(peerInfo.address.inetSocketAddress))
-        .flatMap(_ => Task.fromFuture(activationF))
-        .map(_ => this)
-        .onErrorRecoverWith {
-          case t: Throwable =>
-            Task.raiseError(mapException(t))
-        }
-    }
-
-    override def sendMessage(message: M): Task[Unit] = {
-      Task
-        .fromFuture(activationF)
-        .flatMap(ctx => {
-          log.debug(
-            s"Processing outbound message from local address ${ctx.channel().localAddress()} " +
-              s"to remote address ${ctx.channel().remoteAddress()} via channel id ${ctx.channel().id()}"
-          )
-
-          Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
-            toTask(ctx.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
-          }
-        })
-        .onErrorRecoverWith {
-          case e: IOException =>
-            Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
-        }
-        .map(_ => ())
-    }
-
-    override def in: ConnectableObservable[M] = messageSubject
-
-    override def close(): Task[Unit] = {
-      messageSubject.onComplete()
-      Task
-        .fromFuture(activationF)
-        .flatMap(ctx => toTask(ctx.close()))
-        .flatMap(_ => Task.fromFuture(deactivationF))
-    }
-  }
-
-  private[scalanet] class ServerChannelBuilder[M](
-      serverSubject: ConnectableSubject[ServerEvent[PeerInfo, M]],
-      val nettyChannel: SocketChannel,
-      sslServerCtx: SslContext,
-      codec: StreamCodec[M]
-  )(implicit scheduler: Scheduler) {
-    private val log = LoggerFactory.getLogger(getClass)
-    val sslHandler = sslServerCtx.newHandler(nettyChannel.alloc())
-
-    val messageSubject = ConnectableSubject[M]()
-    val sslEngine = sslHandler.engine()
-
-    nettyChannel
-      .pipeline()
-      .addLast("ssl", sslHandler) //This needs to be first
-      .addLast(new ChannelInboundHandlerAdapter() {
-        override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
-          evt match {
-            case e: SslHandshakeCompletionEvent =>
-              val localAddress = InetMultiAddress(ctx.channel().localAddress().asInstanceOf[InetSocketAddress])
-              val remoteAddress = InetMultiAddress(ctx.channel().remoteAddress().asInstanceOf[InetSocketAddress])
-              if (e.isSuccess) {
-                // Hacky way of getting id of incoming peer form ssl engine. Only works becouse we have new engine for
-                // each connection
-                val params = sslEngine.getSSLParameters.getServerNames.asScala.head
-                val peerId = BitVector(params.getEncoded)
-                log.debug(
-                  s"Ssl Handshake server channel from $localAddress " +
-                    s"to $remoteAddress with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
-                )
-                val channel = new ServerChannelImpl[M](nettyChannel, peerId, codec, messageSubject)
-                serverSubject.onNext(ChannelCreated(channel))
-              } else {
-                // Handshake failed we do not habe id of remote peer
-                serverSubject
-                  .onNext(
-                    PeerGroup.ServerEvent
-                      .HandshakeFailed(new HandshakeException(PeerInfo(BitVector.empty, remoteAddress), e.cause()))
-                  )
-              }
-          }
-        }
-      })
-      .addLast(new MessageNotifier(messageSubject, codec))
-  }
-
-  private[scalanet] class ServerChannelImpl[M](
-      val nettyChannel: SocketChannel,
-      peerId: BitVector,
-      codec: StreamCodec[M],
-      messageSubject: ConnectableSubject[M]
-  )(implicit scheduler: Scheduler)
-      extends Channel[PeerInfo, M] {
-
-    private val log = LoggerFactory.getLogger(getClass)
-
-    log.debug(
-      s"Creating server channel from ${nettyChannel.localAddress()} to ${nettyChannel.remoteAddress()} with channel id ${nettyChannel.id}"
-    )
-
-    override val to: PeerInfo = PeerInfo(peerId, InetMultiAddress(nettyChannel.remoteAddress()))
-
-    override def sendMessage(message: M): Task[Unit] = {
-      Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
-        toTask(nettyChannel.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
-          .onErrorRecoverWith {
-            case e: IOException =>
-              Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
-          }
-      }
-    }
-
-    override def in: ConnectableObservable[M] = messageSubject
-
-    override def close(): Task[Unit] = {
-      messageSubject.onComplete()
-      toTask(nettyChannel.close())
     }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -41,6 +41,7 @@ import scodec.bits.BitVector
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Promise
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -142,16 +143,16 @@ object DynamicTLSPeerGroup {
         keyType: KeyType,
         hostKeyPair: KeyPair,
         secureRandom: SecureRandom
-    ): Config = {
+    ): Try[Config] = {
 
-      val nodeData = SignedKeyExtensionNodeData(keyType, hostKeyPair, Secp256r1, secureRandom).get
-
-      Config(
-        bindAddress,
-        PeerInfo(nodeData.calculatedNodeId, InetMultiAddress(bindAddress)),
-        nodeData.generatedConnectionKey,
-        nodeData.certWithExtension
-      )
+      SignedKeyExtensionNodeData(keyType, hostKeyPair, Secp256r1, secureRandom).map { nodeData =>
+        Config(
+          bindAddress,
+          PeerInfo(nodeData.calculatedNodeId, InetMultiAddress(bindAddress)),
+          nodeData.generatedConnectionKey,
+          nodeData.certWithExtension
+        )
+      }
     }
 
     def apply(
@@ -159,7 +160,7 @@ object DynamicTLSPeerGroup {
         keyType: KeyType,
         hostKeyPair: AsymmetricCipherKeyPair,
         secureRandom: SecureRandom
-    ): Config = {
+    ): Try[Config] = {
       val convertedKeyPair = CryptoUtils.convertBcToJceKeyPair(hostKeyPair)
       Config(bindAddress, keyType, convertedKeyPair, secureRandom)
     }

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -1,0 +1,393 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import java.io.IOException
+import java.net.{ConnectException, InetSocketAddress}
+import java.nio.channels.ClosedChannelException
+import java.security._
+import java.security.cert.X509Certificate
+
+import io.iohk.scalanet.codec.StreamCodec
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.monix_subject.ConnectableSubject
+import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
+import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
+import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
+import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, HandshakeException, ServerEvent, TerminalPeerGroup}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKeyExtensionNodeData
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{
+  ClientChannelImpl,
+  Config,
+  PeerInfo,
+  ServerChannelBuilder
+}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupUtils.{SSLContextForClient, SSLContextForSever}
+import io.iohk.scalanet.peergroup.{Addressable, Channel, InetMultiAddress, PeerGroup}
+import io.netty.bootstrap.{Bootstrap, ServerBootstrap}
+import io.netty.buffer.{ByteBuf, Unpooled}
+import io.netty.channel._
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.{NioServerSocketChannel, NioSocketChannel}
+import io.netty.handler.logging.{LogLevel, LoggingHandler}
+import io.netty.handler.ssl.{SslContext, SslHandshakeCompletionEvent}
+import javax.net.ssl._
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.observables.ConnectableObservable
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.slf4j.LoggerFactory
+import scodec.bits.BitVector
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Promise
+import scala.util.control.NonFatal
+
+/**
+  * PeerGroup implementation on top of TLS.
+  * the encoded bytes provided by the callers codec are not identical to the bytes put on the wire (since a
+  * length field is prepended to the byte stream). This class therefore cannot be used to talk to general services
+  * that are not instances of TLSPeerGroup.
+  *
+  * @param config bind address etc. See the companion object.
+  * @param codec  a decco codec for reading writing messages to NIO ByteBuffer.
+  * @tparam M the message type.
+  */
+class DynamicTLSPeerGroup[M](val config: Config)(
+    implicit codec: StreamCodec[M],
+    scheduler: Scheduler
+) extends TerminalPeerGroup[PeerInfo, M]() {
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForSever, config)
+
+  private val serverSubject = ConnectableSubject[ServerEvent[PeerInfo, M]]()
+
+  private val workerGroup = new NioEventLoopGroup()
+
+  private val clientBootstrap = new Bootstrap()
+    .group(workerGroup)
+    .channel(classOf[NioSocketChannel])
+    .option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
+    .option[RecvByteBufAllocator](ChannelOption.RCVBUF_ALLOCATOR, new DefaultMaxBytesRecvByteBufAllocator)
+    .option[Integer](ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+
+  private val serverBootstrap = new ServerBootstrap()
+    .group(workerGroup)
+    .handler(new LoggingHandler(LogLevel.DEBUG))
+    .channel(classOf[NioServerSocketChannel])
+    .childHandler(new ChannelInitializer[SocketChannel]() {
+      override def initChannel(ch: SocketChannel): Unit = {
+        new ServerChannelBuilder[M](serverSubject, ch, sslServerCtx, codec)
+        log.info(s"$processAddress received inbound from ${ch.remoteAddress()}.")
+      }
+    })
+    .option[Integer](ChannelOption.SO_BACKLOG, 128)
+    .option[RecvByteBufAllocator](ChannelOption.RCVBUF_ALLOCATOR, new DefaultMaxBytesRecvByteBufAllocator)
+    .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
+
+  private lazy val serverBind: ChannelFuture = serverBootstrap.bind(config.bindAddress)
+
+  override def initialize(): Task[Unit] =
+    toTask(serverBind).map(_ => log.info(s"Server bound to address ${config.bindAddress}")).onErrorRecoverWith {
+      case NonFatal(e) => Task.raiseError(InitializationError(e.getMessage, e.getCause))
+    }
+
+  override def processAddress: PeerInfo = config.peerInfo
+
+  override def client(to: PeerInfo): Task[Channel[PeerInfo, M]] = {
+    // Creating new ssl context for each client is necessary, as this is only reliable way to pass peerInfo to TrustManager
+    // which takes care of validating certificates and server node id.
+    // Using Netty SSLEngine.getSession.putValue does not work as expected as until successfulhandshake there is no separate
+    // session for each connection.
+    new ClientChannelImpl[M](
+      to,
+      clientBootstrap,
+      DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForClient(to), config),
+      codec
+    ).initialize
+  }
+
+  override def server(): ConnectableObservable[ServerEvent[PeerInfo, M]] = serverSubject
+
+  override def shutdown(): Task[Unit] = {
+    serverSubject.onComplete()
+    for {
+      _ <- toTask(serverBind.channel().close())
+      _ <- toTask(workerGroup.shutdownGracefully())
+    } yield ()
+  }
+}
+
+object DynamicTLSPeerGroup {
+  case class PeerInfo(id: BitVector, address: InetMultiAddress)
+  object PeerInfo {
+    implicit val peerInInst = new Addressable[PeerInfo] {
+      override def getAddress(a: PeerInfo): InetSocketAddress = a.address.inetSocketAddress
+    }
+  }
+
+  case class Config(
+      bindAddress: InetSocketAddress,
+      peerInfo: PeerInfo,
+      connectionKeyPair: KeyPair,
+      connectionCertificate: X509Certificate
+  )
+
+  object Config {
+    // FIXME: For now we support only Secp256 keys in ethereum format
+    def apply(
+        bindAddress: InetSocketAddress,
+        keyType: KeyType,
+        hostKeyPair: KeyPair,
+        secureRandom: SecureRandom
+    ): Config = {
+
+      val nodeData = SignedKeyExtensionNodeData(keyType, hostKeyPair, Secp256r1, secureRandom).get
+
+      Config(
+        bindAddress,
+        PeerInfo(nodeData.calculatedNodeId, InetMultiAddress(bindAddress)),
+        nodeData.generatedConnectionKey,
+        nodeData.certWithExtension
+      )
+    }
+
+    def apply(
+        bindAddress: InetSocketAddress,
+        keyType: KeyType,
+        hostKeyPair: AsymmetricCipherKeyPair,
+        secureRandom: SecureRandom
+    ): Config = {
+      val convertedKeyPair = CryptoUtils.convertBcToJceKeyPair(hostKeyPair)
+      Config(bindAddress, keyType, convertedKeyPair, secureRandom)
+    }
+  }
+
+  private class MessageNotifier[M](
+      val messageSubject: ConnectableSubject[M],
+      codec: StreamCodec[M]
+  ) extends ChannelInboundHandlerAdapter {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    override def channelInactive(channelHandlerContext: ChannelHandlerContext): Unit =
+      messageSubject.onComplete()
+
+    override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
+      val byteBuf = msg.asInstanceOf[ByteBuf]
+      try {
+        log.info(
+          s"Processing inbound message from remote address ${ctx.channel().remoteAddress()} " +
+            s"to local address ${ctx.channel().localAddress()}"
+        )
+        codec
+          .streamDecode(BitVector(byteBuf.nioBuffer()))
+          .foreach(message => messageSubject.onNext(message))
+      } finally {
+        byteBuf.release()
+      }
+    }
+
+    override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+      // swallow netty's default logging of the stack trace.
+    }
+  }
+
+  private class ClientChannelImpl[M](
+      peerInfo: PeerInfo,
+      clientBootstrap: Bootstrap,
+      sslClientCtx: SslContext,
+      codec: StreamCodec[M]
+  )(implicit scheduler: Scheduler)
+      extends Channel[PeerInfo, M] {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    val to: PeerInfo = peerInfo
+
+    private val activation = Promise[ChannelHandlerContext]()
+    private val activationF = activation.future
+
+    private val deactivation = Promise[Unit]()
+    private val deactivationF = deactivation.future
+
+    private val messageSubject = ConnectableSubject[M]()
+
+    private val bootstrap: Bootstrap = clientBootstrap
+      .clone()
+      .handler(new ChannelInitializer[SocketChannel]() {
+        def initChannel(ch: SocketChannel): Unit = {
+          val pipeline = ch.pipeline()
+          val sslHandler = sslClientCtx.newHandler(ch.alloc())
+
+          pipeline
+            .addLast("ssl", sslHandler) //This needs to be first
+            .addLast(new ChannelInboundHandlerAdapter() {
+
+              override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+                deactivation.success(())
+              }
+
+              override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
+                evt match {
+                  case e: SslHandshakeCompletionEvent =>
+                    log.info(
+                      s"Ssl Handshake client channel from ${ctx.channel().localAddress()} " +
+                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
+                    )
+                    if (e.isSuccess)
+                      activation.success(ctx)
+                    else {
+                      activation.failure(e.cause())
+                    }
+
+                  case _ =>
+                    log.info(
+                      s"User Event client channel from ${ctx.channel().localAddress()} " +
+                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id}"
+                    )
+                }
+              }
+            })
+            .addLast(new MessageNotifier[M](messageSubject, codec))
+        }
+      })
+
+    private def mapException(t: Throwable): Throwable = t match {
+      case _: ClosedChannelException =>
+        new PeerGroup.ChannelBrokenException(to, t)
+      case _: ConnectException =>
+        new PeerGroup.ChannelSetupException(to, t)
+      case _: SSLKeyException =>
+        new PeerGroup.HandshakeException(to, t)
+      case e: SSLHandshakeException =>
+        new PeerGroup.HandshakeException(to, t)
+      case _ =>
+        t
+    }
+
+    def initialize: Task[ClientChannelImpl[M]] = {
+      toTask(bootstrap.connect(peerInfo.address.inetSocketAddress))
+        .flatMap(_ => Task.fromFuture(activationF))
+        .map(_ => this)
+        .onErrorRecoverWith {
+          case t: Throwable =>
+            Task.raiseError(mapException(t))
+        }
+    }
+
+    override def sendMessage(message: M): Task[Unit] = {
+      Task
+        .fromFuture(activationF)
+        .flatMap(ctx => {
+          log.debug(
+            s"Processing outbound message from local address ${ctx.channel().localAddress()} " +
+              s"to remote address ${ctx.channel().remoteAddress()} via channel id ${ctx.channel().id()}"
+          )
+
+          Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
+            toTask(ctx.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
+          }
+        })
+        .onErrorRecoverWith {
+          case e: IOException =>
+            Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
+        }
+        .map(_ => ())
+    }
+
+    override def in: ConnectableObservable[M] = messageSubject
+
+    override def close(): Task[Unit] = {
+      messageSubject.onComplete()
+      Task
+        .fromFuture(activationF)
+        .flatMap(ctx => toTask(ctx.close()))
+        .flatMap(_ => Task.fromFuture(deactivationF))
+    }
+  }
+
+  private[scalanet] class ServerChannelBuilder[M](
+      serverSubject: ConnectableSubject[ServerEvent[PeerInfo, M]],
+      val nettyChannel: SocketChannel,
+      sslServerCtx: SslContext,
+      codec: StreamCodec[M]
+  )(implicit scheduler: Scheduler) {
+    private val log = LoggerFactory.getLogger(getClass)
+    val sslHandler = sslServerCtx.newHandler(nettyChannel.alloc())
+
+    val messageSubject = ConnectableSubject[M]()
+    val sslEngine = sslHandler.engine()
+
+    nettyChannel
+      .pipeline()
+      .addLast("ssl", sslHandler) //This needs to be first
+      .addLast(new ChannelInboundHandlerAdapter() {
+        override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
+          evt match {
+            case e: SslHandshakeCompletionEvent =>
+              val localAddress = InetMultiAddress(ctx.channel().localAddress().asInstanceOf[InetSocketAddress])
+              val remoteAddress = InetMultiAddress(ctx.channel().remoteAddress().asInstanceOf[InetSocketAddress])
+              if (e.isSuccess) {
+                // Hacky way of getting id of incoming peer form ssl engine. Only works becouse we have new engine for
+                // each connection
+                val params = sslEngine.getSSLParameters.getServerNames.asScala.head
+                val peerId = BitVector(params.getEncoded)
+                log.debug(
+                  s"Ssl Handshake server channel from $localAddress " +
+                    s"to $remoteAddress with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
+                )
+                val channel = new ServerChannelImpl[M](nettyChannel, peerId, codec, messageSubject)
+                serverSubject.onNext(ChannelCreated(channel))
+              } else {
+                println(s"WOOOWO HANDSHAGE DAILED ${e}")
+                // Handshake failed we do not habe id of remote peer
+                serverSubject
+                  .onNext(
+                    PeerGroup.ServerEvent
+                      .HandshakeFailed(new HandshakeException(PeerInfo(BitVector.empty, remoteAddress), e.cause()))
+                  )
+              }
+          }
+        }
+      })
+      .addLast(new MessageNotifier(messageSubject, codec))
+  }
+
+  private[scalanet] class ServerChannelImpl[M](
+      val nettyChannel: SocketChannel,
+      peerId: BitVector,
+      codec: StreamCodec[M],
+      messageSubject: ConnectableSubject[M]
+  )(implicit scheduler: Scheduler)
+      extends Channel[PeerInfo, M] {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    log.debug(
+      s"Creating server channel from ${nettyChannel.localAddress()} to ${nettyChannel.remoteAddress()} with channel id ${nettyChannel.id}"
+    )
+
+    override val to: PeerInfo = PeerInfo(peerId, InetMultiAddress(nettyChannel.remoteAddress()))
+
+    override def sendMessage(message: M): Task[Unit] = {
+      Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
+        toTask(nettyChannel.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
+          .onErrorRecoverWith {
+            case e: IOException =>
+              Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
+          }
+      }
+    }
+
+    override def in: ConnectableObservable[M] = messageSubject
+
+    override def close(): Task[Unit] = {
+      messageSubject.onComplete()
+      toTask(nettyChannel.close())
+    }
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -262,7 +262,9 @@ object DynamicTLSPeerGroup {
         new PeerGroup.ChannelSetupException(to, t)
       case _: SSLKeyException =>
         new PeerGroup.HandshakeException(to, t)
-      case e: SSLHandshakeException =>
+      case _: SSLHandshakeException =>
+        new PeerGroup.HandshakeException(to, t)
+      case _: SSLException =>
         new PeerGroup.HandshakeException(to, t)
       case _ =>
         t
@@ -342,7 +344,6 @@ object DynamicTLSPeerGroup {
                 val channel = new ServerChannelImpl[M](nettyChannel, peerId, codec, messageSubject)
                 serverSubject.onNext(ChannelCreated(channel))
               } else {
-                println(s"WOOOWO HANDSHAGE DAILED ${e}")
                 // Handshake failed we do not habe id of remote peer
                 serverSubject
                   .onNext(

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -1,0 +1,256 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import java.io.IOException
+import java.net.{ConnectException, InetSocketAddress}
+import java.nio.channels.ClosedChannelException
+
+import io.iohk.scalanet.codec.StreamCodec
+import io.iohk.scalanet.monix_subject.ConnectableSubject
+import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
+import io.iohk.scalanet.peergroup.{Channel, InetMultiAddress, PeerGroup}
+import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, HandshakeException, ServerEvent}
+import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.PeerInfo
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.{ByteBuf, Unpooled}
+import io.netty.channel.{ChannelHandlerContext, ChannelInboundHandlerAdapter, ChannelInitializer}
+import io.netty.channel.socket.SocketChannel
+import io.netty.handler.ssl.{SslContext, SslHandshakeCompletionEvent}
+import javax.net.ssl.{SSLException, SSLHandshakeException, SSLKeyException}
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.observables.ConnectableObservable
+import org.slf4j.LoggerFactory
+import scodec.bits.BitVector
+import scala.collection.JavaConverters._
+
+import scala.concurrent.Promise
+
+private[dynamictls] object DynamicTLSPeerGroupInternals {
+  class MessageNotifier[M](
+      val messageSubject: ConnectableSubject[M],
+      codec: StreamCodec[M]
+  ) extends ChannelInboundHandlerAdapter {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    override def channelInactive(channelHandlerContext: ChannelHandlerContext): Unit =
+      messageSubject.onComplete()
+
+    override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
+      val byteBuf = msg.asInstanceOf[ByteBuf]
+      try {
+        log.info(
+          s"Processing inbound message from remote address ${ctx.channel().remoteAddress()} " +
+            s"to local address ${ctx.channel().localAddress()}"
+        )
+        codec
+          .streamDecode(BitVector(byteBuf.nioBuffer()))
+          .foreach(message => messageSubject.onNext(message))
+      } finally {
+        byteBuf.release()
+      }
+    }
+
+    override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+      // swallow netty's default logging of the stack trace.
+    }
+  }
+
+  class ClientChannelImpl[M](
+      peerInfo: PeerInfo,
+      clientBootstrap: Bootstrap,
+      sslClientCtx: SslContext,
+      codec: StreamCodec[M]
+  )(implicit scheduler: Scheduler)
+      extends Channel[PeerInfo, M] {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    val to: PeerInfo = peerInfo
+
+    private val activation = Promise[ChannelHandlerContext]()
+    private val activationF = activation.future
+
+    private val deactivation = Promise[Unit]()
+    private val deactivationF = deactivation.future
+
+    private val messageSubject = ConnectableSubject[M]()
+
+    private val bootstrap: Bootstrap = clientBootstrap
+      .clone()
+      .handler(new ChannelInitializer[SocketChannel]() {
+        def initChannel(ch: SocketChannel): Unit = {
+          val pipeline = ch.pipeline()
+          val sslHandler = sslClientCtx.newHandler(ch.alloc())
+
+          pipeline
+            .addLast("ssl", sslHandler) //This needs to be first
+            .addLast(new ChannelInboundHandlerAdapter() {
+
+              override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+                deactivation.success(())
+              }
+
+              override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
+                evt match {
+                  case e: SslHandshakeCompletionEvent =>
+                    log.info(
+                      s"Ssl Handshake client channel from ${ctx.channel().localAddress()} " +
+                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
+                    )
+                    if (e.isSuccess)
+                      activation.success(ctx)
+                    else {
+                      activation.failure(e.cause())
+                    }
+
+                  case _ =>
+                    log.info(
+                      s"User Event client channel from ${ctx.channel().localAddress()} " +
+                        s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id}"
+                    )
+                }
+              }
+            })
+            .addLast(new MessageNotifier[M](messageSubject, codec))
+        }
+      })
+
+    private def mapException(t: Throwable): Throwable = t match {
+      case _: ClosedChannelException =>
+        new PeerGroup.ChannelBrokenException(to, t)
+      case _: ConnectException =>
+        new PeerGroup.ChannelSetupException(to, t)
+      case _: SSLKeyException =>
+        new PeerGroup.HandshakeException(to, t)
+      case _: SSLHandshakeException =>
+        new PeerGroup.HandshakeException(to, t)
+      case _: SSLException =>
+        new PeerGroup.HandshakeException(to, t)
+      case _ =>
+        t
+    }
+
+    def initialize: Task[ClientChannelImpl[M]] = {
+      toTask(bootstrap.connect(peerInfo.address.inetSocketAddress))
+        .flatMap(_ => Task.fromFuture(activationF))
+        .map(_ => this)
+        .onErrorRecoverWith {
+          case t: Throwable =>
+            Task.raiseError(mapException(t))
+        }
+    }
+
+    override def sendMessage(message: M): Task[Unit] = {
+      Task
+        .fromFuture(activationF)
+        .flatMap(ctx => {
+          log.debug(
+            s"Processing outbound message from local address ${ctx.channel().localAddress()} " +
+              s"to remote address ${ctx.channel().remoteAddress()} via channel id ${ctx.channel().id()}"
+          )
+
+          Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
+            toTask(ctx.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
+          }
+        })
+        .onErrorRecoverWith {
+          case e: IOException =>
+            Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
+        }
+        .map(_ => ())
+    }
+
+    override def in: ConnectableObservable[M] = messageSubject
+
+    override def close(): Task[Unit] = {
+      messageSubject.onComplete()
+      Task
+        .fromFuture(activationF)
+        .flatMap(ctx => toTask(ctx.close()))
+        .flatMap(_ => Task.fromFuture(deactivationF))
+    }
+  }
+
+  class ServerChannelBuilder[M](
+      serverSubject: ConnectableSubject[ServerEvent[PeerInfo, M]],
+      val nettyChannel: SocketChannel,
+      sslServerCtx: SslContext,
+      codec: StreamCodec[M]
+  )(implicit scheduler: Scheduler) {
+    private val log = LoggerFactory.getLogger(getClass)
+    val sslHandler = sslServerCtx.newHandler(nettyChannel.alloc())
+
+    val messageSubject = ConnectableSubject[M]()
+    val sslEngine = sslHandler.engine()
+
+    nettyChannel
+      .pipeline()
+      .addLast("ssl", sslHandler) //This needs to be first
+      .addLast(new ChannelInboundHandlerAdapter() {
+        override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
+          evt match {
+            case e: SslHandshakeCompletionEvent =>
+              val localAddress = InetMultiAddress(ctx.channel().localAddress().asInstanceOf[InetSocketAddress])
+              val remoteAddress = InetMultiAddress(ctx.channel().remoteAddress().asInstanceOf[InetSocketAddress])
+              if (e.isSuccess) {
+                // Hacky way of getting id of incoming peer from ssl engine. Only works because we have new engine for
+                // each connection
+                val params = sslEngine.getSSLParameters.getServerNames.asScala.head
+                val peerId = BitVector(params.getEncoded)
+                log.debug(
+                  s"Ssl Handshake server channel from $localAddress " +
+                    s"to $remoteAddress with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
+                )
+                val channel = new ServerChannelImpl[M](nettyChannel, peerId, codec, messageSubject)
+                serverSubject.onNext(ChannelCreated(channel))
+              } else {
+                // Handshake failed we do not habe id of remote peer
+                serverSubject
+                  .onNext(
+                    PeerGroup.ServerEvent
+                      .HandshakeFailed(new HandshakeException(PeerInfo(BitVector.empty, remoteAddress), e.cause()))
+                  )
+              }
+          }
+        }
+      })
+      .addLast(new MessageNotifier(messageSubject, codec))
+  }
+
+  class ServerChannelImpl[M](
+      val nettyChannel: SocketChannel,
+      peerId: BitVector,
+      codec: StreamCodec[M],
+      messageSubject: ConnectableSubject[M]
+  )(implicit scheduler: Scheduler)
+      extends Channel[PeerInfo, M] {
+
+    private val log = LoggerFactory.getLogger(getClass)
+
+    log.debug(
+      s"Creating server channel from ${nettyChannel.localAddress()} to ${nettyChannel.remoteAddress()} with channel id ${nettyChannel.id}"
+    )
+
+    override val to: PeerInfo = PeerInfo(peerId, InetMultiAddress(nettyChannel.remoteAddress()))
+
+    override def sendMessage(message: M): Task[Unit] = {
+      Task.fromTry(codec.encode(message).toTry).flatMap { enc =>
+        toTask(nettyChannel.writeAndFlush(Unpooled.wrappedBuffer(enc.toByteBuffer)))
+          .onErrorRecoverWith {
+            case e: IOException =>
+              Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
+          }
+      }
+    }
+
+    override def in: ConnectableObservable[M] = messageSubject
+
+    override def close(): Task[Unit] = {
+      messageSubject.onComplete()
+      toTask(nettyChannel.close())
+    }
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
@@ -1,0 +1,99 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import java.net.Socket
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.PeerInfo
+import io.netty.handler.ssl.util.SimpleTrustManagerFactory
+import io.netty.handler.ssl.{ClientAuth, SslContext, SslContextBuilder}
+import javax.net.ssl._
+import scodec.bits.BitVector
+
+import scala.collection.JavaConverters._
+
+private[scalanet] object DynamicTLSPeerGroupUtils {
+  // supporting only ciphers which are used in TLS 1.3
+  val supportedCipherSuites: Seq[String] = Seq(
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  )
+
+  val typeOfIdentificaiton = 0
+
+  class IdIdentification(bytes: Array[Byte]) extends SNIServerName(typeOfIdentificaiton, bytes)
+
+  class DynamicTlsTrustManager(info: Option[BitVector]) extends X509ExtendedTrustManager {
+    override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = ???
+
+    override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = ???
+
+    override def getAcceptedIssuers: Array[X509Certificate] = {
+      new Array[X509Certificate](0)
+    }
+
+    override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String, socket: Socket): Unit = ???
+
+    override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String, sslEngine: SSLEngine): Unit = {
+      CustomTlsValidator.validateCertificates(x509Certificates, info) match {
+        case Left(er) => throw er
+        case Right(value) =>
+          val id = value.publicKey.getNodeId
+          val params = sslEngine.getSSLParameters
+          val listPars: List[SNIServerName] = List(new IdIdentification(id.toByteArray))
+          // A little hack to pass client id to DynamicTlsPeerGroup.
+          params.setServerNames(listPars.asJava)
+          sslEngine.setSSLParameters(params)
+      }
+    }
+
+    override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String, socket: Socket): Unit = ???
+
+    override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String, sslEngine: SSLEngine): Unit = {
+      CustomTlsValidator.validateCertificates(x509Certificates, info) match {
+        case Left(er) => throw er
+        case Right(_) => ()
+      }
+    }
+  }
+
+  class CustomTrustManagerFactory(info: Option[BitVector]) extends SimpleTrustManagerFactory {
+
+    private val tm = new DynamicTlsTrustManager(info)
+
+    override def engineGetTrustManagers(): Array[TrustManager] = {
+      Array[TrustManager] { tm }
+    }
+
+    override def engineInit(keyStore: KeyStore): Unit = {}
+
+    override def engineInit(managerFactoryParameters: ManagerFactoryParameters): Unit = {}
+  }
+
+  sealed trait SSLContextFor
+  case object SSLContextForSever extends SSLContextFor
+  case class SSLContextForClient(to: PeerInfo) extends SSLContextFor
+
+  def buildCustomSSlContext(f: SSLContextFor, config: DynamicTLSPeerGroup.Config): SslContext = {
+    f match {
+      case SSLContextForSever =>
+        SslContextBuilder
+          .forServer(config.connectionKeyPair.getPrivate, List(config.connectionCertificate): _*)
+          .trustManager(new CustomTrustManagerFactory(None))
+          .clientAuth(ClientAuth.REQUIRE)
+          .ciphers(supportedCipherSuites.asJava)
+          .protocols("TLSv1.2")
+          .build()
+
+      case SSLContextForClient(info) =>
+        SslContextBuilder
+          .forClient()
+          .keyManager(config.connectionKeyPair.getPrivate, List(config.connectionCertificate): _*)
+          .trustManager(new CustomTrustManagerFactory(Some(info.id)))
+          .ciphers(supportedCipherSuites.asJava)
+          .protocols("TLSv1.2")
+          .build()
+    }
+  }
+
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
@@ -82,12 +82,12 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
   }
 
   sealed trait SSLContextFor
-  case object SSLContextForSever extends SSLContextFor
+  case object SSLContextForServer extends SSLContextFor
   case class SSLContextForClient(to: PeerInfo) extends SSLContextFor
 
   def buildCustomSSlContext(f: SSLContextFor, config: DynamicTLSPeerGroup.Config): SslContext = {
     f match {
-      case SSLContextForSever =>
+      case SSLContextForServer =>
         SslContextBuilder
           .forServer(config.connectionKeyPair.getPrivate, List(config.connectionCertificate): _*)
           .trustManager(new CustomTrustManagerFactory(None))

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
@@ -23,6 +23,17 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
 
   class IdIdentification(bytes: Array[Byte]) extends SNIServerName(typeOfIdentificaiton, bytes)
 
+  /**
+    *
+    * Custom manager which is used by netty ssl to accept or reject peer certificates.
+    *
+    * Extended version is needed to have access to SslEngine to, to pass client id to other parts of the system
+    * via getSSLParameters
+    *
+    * Methods without SslEngine argument are left with `???` to make sure that if there would arise case that they would
+    * be called, then exception will be thrown instead of just trusting external peer without validations.
+    *
+    */
   class DynamicTlsTrustManager(info: Option[BitVector]) extends X509ExtendedTrustManager {
     override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = ???
 

--- a/scalanet/test/src/io/iohk/scalanet/crypto/SignatureVerificationSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/crypto/SignatureVerificationSpec.scala
@@ -1,0 +1,67 @@
+package io.iohk.scalanet.crypto
+
+import java.security.SecureRandom
+
+import io.iohk.scalanet.peergroup.dynamictls.Secp256k1
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+import io.iohk.scalanet.testutils.GeneratorUtils
+import org.scalacheck.Gen
+
+class SignatureVerificationSpec extends FlatSpec with Matchers {
+  val rnd = new SecureRandom()
+  val minDataSize = 0
+  val maxDataSize = 1024
+
+  "Signature verification" should "success for all properly signed data" in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(minDataSize, maxDataSize)) { data =>
+      val key = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+      val sig = CryptoUtils.signEcdsa(data, key.getPrivate, rnd)
+      val verification = CryptoUtils.verifyEcdsa(data, sig, key.getPublic)
+      assert(verification)
+    }
+  }
+
+  it should "success for bouncy castle converted keys" in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(minDataSize, maxDataSize)) { data =>
+      val bcKey = CryptoUtils.generateKeyPair(rnd)
+      val key = CryptoUtils.convertBcToJceKeyPair(bcKey)
+      val sig = CryptoUtils.signEcdsa(data, key.getPrivate, rnd)
+      val verification = CryptoUtils.verifyEcdsa(data, sig, key.getPublic)
+      assert(verification)
+    }
+  }
+
+  it should "fail when verifying with wrong public key" in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(minDataSize, maxDataSize)) { data =>
+      val key = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+      val key1 = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+      val sig = CryptoUtils.signEcdsa(data, key.getPrivate, rnd)
+      val verification = CryptoUtils.verifyEcdsa(data, sig, key1.getPublic)
+      assert(!verification)
+    }
+  }
+
+  it should "fail when verifying with changed signature " in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(minDataSize, maxDataSize), Gen.choose(10, 40)) { (data, idx) =>
+      val key = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+      val sig = CryptoUtils.signEcdsa(data, key.getPrivate, rnd)
+      val newByte = (sig(idx) + 1).toByte
+      sig(idx) = newByte
+      val verification = CryptoUtils.verifyEcdsa(data, sig, key.getPublic)
+      assert(!verification)
+    }
+  }
+
+  it should "fail when verifying with changed data " in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(50, maxDataSize), Gen.choose(10, 40)) { (data, idx) =>
+      val key = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+      val sig = CryptoUtils.signEcdsa(data, key.getPrivate, rnd)
+      val newByte = (data(idx) + 1).toByte
+      data(idx) = newByte
+      val verification = CryptoUtils.verifyEcdsa(data, sig, key.getPublic)
+      assert(!verification)
+    }
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/dynamictls/CustomTlsValidatorSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/dynamictls/CustomTlsValidatorSpec.scala
@@ -1,0 +1,120 @@
+package io.iohk.scalanet.dynamictls
+
+import java.security.SecureRandom
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+import java.util.Date
+
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.peergroup.dynamictls.CustomTlsValidator.{
+  NoCertExtension,
+  SeverIdNotMatchExpected,
+  WrongCertificateDate,
+  WrongExtensionFormat,
+  WrongExtensionSignature,
+  WrongNumberOfCertificates
+}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.{Extension, SignedKey, SignedKeyExtensionNodeData}
+import io.iohk.scalanet.peergroup.dynamictls.{CustomTlsValidator, Secp256k1}
+import io.iohk.scalanet.testutils.GeneratorUtils
+import org.bouncycastle.asn1.DERGeneralString
+import org.scalatest.prop.GeneratorDrivenPropertyChecks.forAll
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+import org.scalatest.{FlatSpec, Matchers}
+import scodec.bits.BitVector
+
+class CustomTlsValidatorSpec extends FlatSpec with Matchers {
+  val rnd = new SecureRandom()
+  val today = LocalDateTime.now(Clock.systemUTC())
+  val beforeDate = Date.from(today.minusMonths(1).toInstant(ZoneOffset.UTC))
+  val afterDate = Date.from(today.plusYears(100).toInstant(ZoneOffset.UTC))
+
+  "CustomTlsValidator" should "successfully validate client certificates" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
+      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+      val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), None)
+      assert(result.isRight)
+    }
+  }
+
+  it should "successfully validate server certificates" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
+      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+      val result =
+        CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), Some(extension.calculatedNodeId))
+      assert(result.isRight)
+    }
+  }
+
+  it should "fail to validate server with bad id" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd), GeneratorUtils.byteArrayOfNItemsGen(64)) {
+      (keyPair, badId) =>
+        val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+        val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), Some(BitVector(badId)))
+        assert(result == Left(SeverIdNotMatchExpected))
+    }
+  }
+
+  it should "fail to validate wrong number of certificates" in {
+    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+
+    val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), None)
+    assert(result.isRight)
+
+    val result1 = CustomTlsValidator.validateCertificates(Array(), None)
+    assert(result1 == Left(WrongNumberOfCertificates))
+
+    val result2 =
+      CustomTlsValidator.validateCertificates(Array(extension.certWithExtension, extension.certWithExtension), None)
+    assert(result2 == Left(WrongNumberOfCertificates))
+  }
+
+  it should "fail to validate certificate without required extension" in {
+    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val cer = CryptoUtils.buildCertificateWithExtensions(keyPair, rnd, List(), beforeDate, afterDate)
+    val result = CustomTlsValidator.validateCertificates(Array(cer), None)
+    assert(result == Left(NoCertExtension))
+  }
+
+  it should "fail to validate certificate with some wrong extension" in {
+    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val badExtension =
+      Extension(SignedKey.signedKeyExtensionIdentifier, isCritical = true, new DERGeneralString("randomstring"))
+    val cer = CryptoUtils.buildCertificateWithExtensions(keyPair, rnd, List(badExtension), beforeDate, afterDate)
+    val result = CustomTlsValidator.validateCertificates(Array(cer), None)
+    assert(result == Left(WrongExtensionFormat))
+  }
+
+  it should "fail to validate certificate with wrong dates" in {
+    val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val connectionKeyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
+    val connectionKeyPairPublicKeyAsBytes = CryptoUtils.getEcPublicKey(connectionKeyPair.getPublic).get
+    val (_, extension) =
+      SignedKey.buildSignedKeyExtension(Secp256k1, hostkeyPair, connectionKeyPairPublicKeyAsBytes, rnd).require
+
+    val notValidBeforeDate = Date.from(today.plusYears(1).toInstant(ZoneOffset.UTC))
+    val cer =
+      CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), notValidBeforeDate, afterDate)
+    val result = CustomTlsValidator.validateCertificates(Array(cer), None)
+    assert(result == Left(WrongCertificateDate))
+
+    val notValidAfterDate = Date.from(today.minusDays(1).toInstant(ZoneOffset.UTC))
+    val cer1 =
+      CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), beforeDate, notValidAfterDate)
+    val result1 = CustomTlsValidator.validateCertificates(Array(cer1), None)
+    assert(result1 == Left(WrongCertificateDate))
+  }
+
+  it should "fail to validate certificate with wrong extension signature" in {
+    val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val connectionKeyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
+    val fakeKey = BitVector(GeneratorUtils.byteArrayOfNItemsGen(64).sample.get)
+    val (_, extension) = SignedKey.buildSignedKeyExtension(Secp256k1, hostkeyPair, fakeKey, rnd).require
+
+    val cer = CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), beforeDate, afterDate)
+    val result = CustomTlsValidator.validateCertificates(Array(cer), None)
+    assert(result == Left(WrongExtensionSignature))
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/dynamictls/SignedKeyExtensionSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/dynamictls/SignedKeyExtensionSpec.scala
@@ -1,0 +1,73 @@
+package io.iohk.scalanet.dynamictls
+
+import java.security.SecureRandom
+
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.{
+  ExtensionPublicKey,
+  SignedKey,
+  SignedKeyExtensionNodeData
+}
+import io.iohk.scalanet.peergroup.dynamictls.Secp256k1
+import io.iohk.scalanet.testutils.GeneratorUtils
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+class SignedKeyExtensionSpec extends FlatSpec with Matchers {
+  val rnd = new SecureRandom()
+
+  "SignedKeyExtension" should "create extension from correct data" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
+      val extension = ExtensionPublicKey(Secp256k1, keyPair.getPublic)
+      assert(extension.isSuccess)
+    }
+  }
+
+  it should "create extension from converted key" in {
+    val keyPair = CryptoUtils.generateKeyPair(rnd)
+    val converted = CryptoUtils.convertBcToJceKeyPair(keyPair)
+    val extension = ExtensionPublicKey(Secp256k1, converted.getPublic)
+    assert(extension.isSuccess)
+  }
+
+  it should "not create extension from wrong key" in {
+    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256r1.name)
+    val extension = ExtensionPublicKey(Secp256k1, keyPair.getPublic)
+    assert(extension.isFailure)
+  }
+
+  it should "encode and decode correct extension" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
+      val extension = ExtensionPublicKey(Secp256k1, keyPair.getPublic).get
+      val enc = ExtensionPublicKey.extensionPublicKeyCodec.encode(extension).require
+      val dec = ExtensionPublicKey.extensionPublicKeyCodec.decodeValue(enc).require
+      assert(extension == dec)
+    }
+  }
+
+  it should "successfully build extension node data" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { hostKey =>
+      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd)
+      assert(nodeData.isSuccess)
+    }
+  }
+
+  it should "successfully parse node data from extension" in {
+    forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { hostKey =>
+      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd).get
+      val extensionBytes = nodeData.certWithExtension.getExtensionValue(SignedKey.extensionIdentifier)
+      val recoveredSignedKey = SignedKey.parseAsn1EncodedValue(extensionBytes)
+      assert(recoveredSignedKey.isSuccessful)
+      assert(recoveredSignedKey.require.publicKey.getNodeId == nodeData.calculatedNodeId)
+    }
+  }
+
+  it should "fail to parse random bytes without throwing exceptions" in {
+    forAll(GeneratorUtils.randomSizeByteArrayGen(0, 1024)) { randomBytes =>
+      val recoveredSignedKey = SignedKey.parseAsn1EncodedValue(randomBytes)
+      assert(recoveredSignedKey.isFailure)
+    }
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -1,0 +1,152 @@
+package io.iohk.scalanet.peergroup
+
+import java.net.InetSocketAddress
+import java.security.SecureRandom
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+import java.util.Date
+
+import io.iohk.scalanet.NetUtils._
+import io.iohk.scalanet.codec.FramingCodec
+import io.iohk.scalanet.crypto.CryptoUtils
+import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.peergroup.DynamicTLSPeerGroupSpec._
+import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, ChannelSetupException, HandshakeException}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKey
+import io.iohk.scalanet.peergroup.dynamictls.{DynamicTLSPeerGroup, Secp256k1}
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{Config, PeerInfo}
+import io.iohk.scalanet.testutils.GeneratorUtils
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{Assertion, AsyncFlatSpec, BeforeAndAfterAll}
+import scodec.Codec
+import scodec.bits.BitVector
+import scodec.codecs.implicits._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class DynamicTLSPeerGroupSpec extends AsyncFlatSpec with BeforeAndAfterAll {
+  implicit val patienceConfig: ScalaFutures.PatienceConfig = PatienceConfig(5 seconds)
+  implicit val codec = new FramingCodec(Codec[String])
+  implicit val scheduler = Scheduler.fixedPool("test", 16)
+
+  behavior of "Dynamic TLSPeerGroup"
+
+  it should "handshake successfully" in taskTestCase {
+    val client = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    val server = new DynamicTLSPeerGroup[String](getCorrectConfig())
+
+    for {
+      _ <- client.initialize()
+      _ <- server.initialize()
+      ch1 <- client.client(server.processAddress)
+      _ <- ch1.sendMessage("Hello enc server")
+      rec <- server.server().refCount.collectChannelCreated.mergeMap(ch => ch.in.refCount).headL
+    } yield {
+      rec shouldEqual "Hello enc server"
+    }
+  }
+
+  it should "fail to connect to offline peer" in taskTestCase {
+    val client = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    val server = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    for {
+      _ <- client.initialize()
+      ch1 <- client.client(server.processAddress).attempt
+    } yield {
+      ch1.isLeft shouldEqual true
+      ch1.left.get shouldBe a[ChannelSetupException[_]]
+    }
+  }
+
+  it should "report error when trying to send message through closed channel" in taskTestCase {
+    val client = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    val server = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    for {
+      _ <- client.initialize()
+      _ <- server.initialize()
+      ch1 <- client.client(server.processAddress)
+      _ <- server.shutdown()
+      result <- ch1.sendMessage("wow").attempt
+    } yield {
+      result.isLeft shouldEqual true
+      result.left.get shouldBe a[ChannelBrokenException[_]]
+    }
+  }
+
+  it should "handle ssl handshake failure becouse of server" in taskTestCase {
+    val client = new DynamicTLSPeerGroup[String](getCorrectConfig())
+    val server = new DynamicTLSPeerGroup[String](getIncorrectConfigWrongId())
+
+    for {
+      _ <- client.initialize()
+      _ <- server.initialize()
+      ch1 <- client.client(server.processAddress).attempt
+      serverHandshake <- server.server().refCount.collectHandshakeFailure.headL
+    } yield {
+      ch1.isLeft shouldEqual true
+      ch1.left.get shouldBe a[HandshakeException[_]]
+      serverHandshake shouldBe a[HandshakeException[_]]
+    }
+  }
+
+  it should "handle ssl handshake failure becouse of client" in taskTestCase {
+    val client = new DynamicTLSPeerGroup[String](getIncorrectConfigWrongSig())
+    val server = new DynamicTLSPeerGroup[String](getCorrectConfig())
+
+    for {
+      _ <- client.initialize()
+      _ <- server.initialize()
+      ch1 <- client.client(server.processAddress).attempt
+      serverHandshake <- server.server().refCount.collectHandshakeFailure.headL
+    } yield {
+      ch1.isLeft shouldEqual true
+      ch1.left.get shouldBe a[HandshakeException[_]]
+      serverHandshake shouldBe a[HandshakeException[_]]
+    }
+  }
+}
+
+object DynamicTLSPeerGroupSpec {
+  def taskTestCase(t: => Task[Assertion])(implicit s: Scheduler): Future[Assertion] =
+    t.runToFuture
+
+  val rnd = new SecureRandom()
+
+  def getCorrectConfig(address: InetSocketAddress = aRandomAddress()): DynamicTLSPeerGroup.Config = {
+    val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    Config(address, Secp256k1, hostkeyPair, rnd)
+  }
+
+  def getIncorrectConfigWrongId(address: InetSocketAddress = aRandomAddress()): DynamicTLSPeerGroup.Config = {
+    val correctConfig = getCorrectConfig(address)
+    correctConfig.copy(peerInfo = correctConfig.peerInfo.copy(id = BitVector(1, 0, 1, 2)))
+  }
+
+  def getIncorrectConfigWrongSig(address: InetSocketAddress = aRandomAddress()): DynamicTLSPeerGroup.Config = {
+    val today = LocalDateTime.now(Clock.systemUTC())
+    val beforeDate = Date.from(today.minusMonths(1).toInstant(ZoneOffset.UTC))
+    val afterDate = Date.from(today.plusYears(100).toInstant(ZoneOffset.UTC))
+
+    val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+
+    val connectionKeyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
+
+    val fakeKey = BitVector(GeneratorUtils.byteArrayOfNItemsGen(64).sample.get)
+
+    val (sig, extension) = SignedKey.buildSignedKeyExtension(Secp256k1, hostkeyPair, fakeKey, rnd).require
+
+    val cer = CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), beforeDate, afterDate)
+
+    DynamicTLSPeerGroup.Config(
+      address,
+      PeerInfo(sig.publicKey.getNodeId, InetMultiAddress(address)),
+      connectionKeyPair,
+      cer
+    )
+  }
+
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -118,7 +118,7 @@ object DynamicTLSPeerGroupSpec {
 
   def getCorrectConfig(address: InetSocketAddress = aRandomAddress()): DynamicTLSPeerGroup.Config = {
     val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
-    Config(address, Secp256k1, hostkeyPair, rnd)
+    Config(address, Secp256k1, hostkeyPair, rnd).get
   }
 
   def getIncorrectConfigWrongId(address: InetSocketAddress = aRandomAddress()): DynamicTLSPeerGroup.Config = {

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
@@ -33,7 +33,7 @@ class TransportPeerGroupAsyncSpec extends AsyncFlatSpec with BeforeAndAfterAll {
     ("Label", "Transport type"),
     ("TCP", Tcp),
     ("UDP", Udp),
-    ("DTLS", DTLS)
+    ("DTLS", DynamicTLS)
   )
   forAll(rpcs) { (label, transportType) =>
     import TransportPeerGroupAsyncSpec._

--- a/scalanet/test/src/io/iohk/scalanet/testutils/GeneratorUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/testutils/GeneratorUtils.scala
@@ -1,0 +1,20 @@
+package io.iohk.scalanet.testutils
+
+import java.security.{KeyPair, SecureRandom}
+
+import io.iohk.scalanet.crypto.CryptoUtils
+import org.scalacheck.{Arbitrary, Gen}
+
+object GeneratorUtils {
+  def genKey(curveName: String, rnd: SecureRandom): Gen[KeyPair] = {
+    Gen.resultOf { s: String =>
+      CryptoUtils.genEcKeyPair(rnd, curveName)
+    }
+  }
+
+  def randomSizeByteArrayGen(minSize: Int, maxSize: Int): Gen[Array[Byte]] =
+    Gen.choose(minSize, maxSize).flatMap(byteArrayOfNItemsGen)
+
+  def byteArrayOfNItemsGen(n: Int): Gen[Array[Byte]] = Gen.listOfN(n, Arbitrary.arbitrary[Byte]).map(_.toArray)
+
+}


### PR DESCRIPTION
TLS peer group suitable for p2p setting, based on libp2p specs: https://github.com/libp2p/specs/blob/master/tls/tls.md

Notable differences:
- Only support one key type - Secp256k1, and only in Ethereum format i.e public key is 65 bytes, where first byte signalise if key is compressed or not, and last 64 bytes are public uncompressed point on Secp256k1 curve. We are supporting only this format as this is current key used by midnight.
- Do not use protobufs to serialize  extension. It is not critical at this stage. For public key we use simple format as: first 8 bits signalise key type, rest of the data is public key.
- We do not have tls 1.3. On java it is supported only from java 11 which does not play nice with scala yet. There is some native option available in netty, but it would require a little bit experimentation.


