### PR TITLE
[PM-1287] Change channel interface

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -14,7 +14,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.10"
 
-  def publishVersion = "0.1.9-SNAPSHOT"
+  def publishVersion = "0.1.10-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -1,5 +1,6 @@
 package io.iohk.scalanet.peergroup
 
+import io.iohk.scalanet.peergroup.Channel.ChannelEvent
 import scodec.Codec
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent
@@ -47,7 +48,7 @@ trait Channel[A, M] {
   /**
     * The inbound stream of messages coming from the remote peer.
     */
-  def in: ConnectableObservable[M]
+  def in: ConnectableObservable[ChannelEvent[M]]
 
   /**
     * Terminate the Channel and clean up any resources.
@@ -56,6 +57,13 @@ trait Channel[A, M] {
     *         and return a successful Task.
     */
   def close(): Task[Unit]
+}
+
+object Channel {
+  sealed abstract class ChannelEvent[+M]
+  final case class MessageReceived[M](m: M) extends ChannelEvent[M]
+  final case class UnexpectedError(e: Throwable) extends ChannelEvent[Nothing]
+  final case object DecodingError extends ChannelEvent[Nothing]
 }
 
 /**

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -26,6 +26,7 @@ import scodec.bits.BitVector
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Promise
+import scala.util.control.NonFatal
 
 private[dynamictls] object DynamicTLSPeerGroupInternals {
   implicit class ChannelOps(val channel: io.netty.channel.Channel) {
@@ -64,6 +65,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
             log.debug("Decoded {} messages from peer {}", value.size, ctx.channel().remoteAddress())
             value.foreach(m => messageSubject.onNext(MessageReceived(m)))
         }
+      } catch {
+        case NonFatal(e) => messageSubject.onNext(UnexpectedError(e))
       } finally {
         byteBuf.release()
       }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/kademlia/KNetworkSpec.scala
@@ -3,7 +3,6 @@ package io.iohk.scalanet.peergroup.kademlia
 import java.util.UUID
 
 import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse
-
 import java.util.concurrent.TimeoutException
 
 import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
@@ -24,6 +23,7 @@ import org.scalatest.concurrent.ScalaFutures._
 import io.iohk.scalanet.TaskValues._
 import KNetworkSpec._
 import io.iohk.scalanet.monix_subject.ConnectableSubject
+import io.iohk.scalanet.peergroup.Channel.MessageReceived
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
 import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -54,7 +54,7 @@ class KNetworkSpec extends FlatSpec {
       val channel = mock[Channel[String, KMessage[String]]]
       when(peerGroup.server())
         .thenReturn(ConnectableSubject(Observable.eval(ChannelCreated(channel))))
-      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(request)))
+      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(request))))
       when(channel.close()).thenReturn(Task.unit)
 
       val actualRequest = requestExtractor(network).evaluated
@@ -82,7 +82,7 @@ class KNetworkSpec extends FlatSpec {
       val channel = mock[Channel[String, KMessage[String]]]
       when(peerGroup.server())
         .thenReturn(ConnectableSubject(Observable.eval(ChannelCreated(channel))))
-      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(request)))
+      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(request))))
       when(channel.sendMessage(response)).thenReturn(Task.unit)
       when(channel.close()).thenReturn(Task.unit)
 
@@ -96,7 +96,7 @@ class KNetworkSpec extends FlatSpec {
       val channel = mock[Channel[String, KMessage[String]]]
       when(peerGroup.server())
         .thenReturn(ConnectableSubject(Observable.eval(ChannelCreated(channel))))
-      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(request)))
+      when(channel.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(request))))
       when(channel.sendMessage(response)).thenReturn(Task.never)
       when(channel.close()).thenReturn(Task.unit)
 
@@ -112,7 +112,7 @@ class KNetworkSpec extends FlatSpec {
         .thenReturn(ConnectableSubject(Observable(ChannelCreated(channel1), ChannelCreated(channel2))))
 
       when(channel1.in).thenReturn(ConnectableSubject(Observable.never))
-      when(channel2.in).thenReturn(ConnectableSubject(Observable.eval(request)))
+      when(channel2.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(request))))
 
       when(channel1.close()).thenReturn(Task.unit)
       when(channel2.close()).thenReturn(Task.unit)
@@ -129,7 +129,7 @@ class KNetworkSpec extends FlatSpec {
       val client = mock[Channel[String, KMessage[String]]]
       when(peerGroup.client(targetRecord.routingAddress)).thenReturn(Task(client))
       when(client.sendMessage(request)).thenReturn(Task.unit)
-      when(client.in).thenReturn(ConnectableSubject(Observable.eval(response)))
+      when(client.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(response))))
       when(client.close()).thenReturn(Task.unit)
 
       val actualResponse = clientRpc(network).evaluated
@@ -181,8 +181,8 @@ class KNetworkSpec extends FlatSpec {
     when(peerGroup.server())
       .thenReturn(ConnectableSubject(Observable(ChannelCreated(channel1), ChannelCreated(channel2))))
 
-    when(channel1.in).thenReturn(ConnectableSubject(Observable.eval(findNodes)))
-    when(channel2.in).thenReturn(ConnectableSubject(Observable.eval(ping)))
+    when(channel1.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(findNodes))))
+    when(channel2.in).thenReturn(ConnectableSubject(Observable.eval(MessageReceived(ping))))
 
     when(channel2.sendMessage(pong)).thenReturn(Task.unit)
 


### PR DESCRIPTION
Changes channel interface from:
```
trait Channel[A, M] {
 def in: ConnectableObservable[M]
}
```
to 
```
trait Channel[A, M] {
 def in: ConnectableObservable[ChannelEvent[M]]
}
```


Implementation is as simple as possible ie. one set of channel events for all `PeerGroups`. It make sense as both of our peer groups uses all of those events, and it enables testing of all groups by the same code.

If we would treat scalanet more like generic library probably better and more typesafe design would be to have different set of channel events per peer group (as not all peergroups need to have the same events). Maybe like
```
trait Channel[AddressType, ChannelEvent, Message] {
 def in: ConnectableObservable[Either[ChannelEvent, Message]
}
```
and then in PeerGroup:
```
trait PeerGroup[A, M] {
 type ChannelEvent
 def client(to: A): Task[Channel[A, ChannelEvent, M]]
}

```
But for now it would only complicate things and not add any value for midnight, also we do not know it there will be any more peergroups.

