### PR TITLE
[PM-1857] Change channel closing strategy

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -14,7 +14,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.10"
 
-  def publishVersion = "0.1.10-SNAPSHOT"
+  def publishVersion = "0.1.11-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
@@ -125,10 +125,14 @@ class KademliaIntegrationSpec extends AsyncFlatSpec with BeforeAndAfterAll with 
         selfRecord = randomNode,
         initialNodes = Set(node2.self, node3.self, node4.self),
         testConfig = lowRefConfig
-      ).delayExecution(10.seconds).startAndForget
+      ).delayExecution(10.seconds)
     } yield {
       eventually {
         node1.getPeers.runSyncUnsafe().size shouldEqual 5
+        node2.getPeers.runSyncUnsafe().size shouldEqual 5
+        node3.getPeers.runSyncUnsafe().size shouldEqual 5
+        node4.getPeers.runSyncUnsafe().size shouldEqual 5
+        node5.getPeers.runSyncUnsafe().size shouldEqual 5
       }
     }
   }

--- a/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
@@ -46,6 +46,7 @@ class UDPPeerGroup[M](val config: Config)(
 
   private val workerGroup = new NioEventLoopGroup()
 
+  // all channels in the map are open and active, as upon closing channels are removed from the map
   private[peergroup] val activeChannels = new ConcurrentHashMap[UdpChannelId, ChannelImpl]()
 
   /**
@@ -176,7 +177,7 @@ class UDPPeerGroup[M](val config: Config)(
 
             override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
               // We cannot create UdpChannelId as on udp netty server channel there is no remote peer address.
-              log.info(s"Unexpected server error ${cause.getMessage}")
+              log.error(s"Unexpected server error ${cause.getMessage}")
             }
           })
       }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
@@ -73,7 +73,7 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
       pg2Result <- initUdpPeerGroup[String](address).attempt
     } yield {
       assert(pg2Result.isLeft)
-      assert(pg2Result.left.get.isInstanceOf[InitializationError])
+      pg2Result.left.get shouldBe a[InitializationError]
     }).runSyncUnsafe()
   }
 


### PR DESCRIPTION
Changes closing strategy, to the one that makes sure that makes sure that removing from active channels maps takes place on the same thread as underlying netty channel is working on. It also get rids of not necessary scheduler and config options.