### PR TITLE
[PM-2104] Fix hack in tls group

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -13,7 +13,7 @@ object scalanet extends ScalaModule with PublishModule {
 
   def scalaVersion = "2.12.10"
 
-  def publishVersion = "0.1.13-SNAPSHOT"
+  def publishVersion = "0.1.14-SNAPSHOT"
 
   override def repositories =
     super.repositories ++ Seq(

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
@@ -19,9 +19,8 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
   )
 
-  val typeOfIdentificaiton = 0
-
-  class IdIdentification(bytes: Array[Byte]) extends SNIServerName(typeOfIdentificaiton, bytes)
+  // key for peerId passed in Handshake session, used in sslEngine
+  val peerIdKey = "peerId"
 
   /**
     *
@@ -50,11 +49,7 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
         case Left(er) => throw er
         case Right(value) =>
           val id = value.publicKey.getNodeId
-          val params = sslEngine.getSSLParameters
-          val listPars: List[SNIServerName] = List(new IdIdentification(id.toByteArray))
-          // A little hack to pass client id to DynamicTlsPeerGroup.
-          params.setServerNames(listPars.asJava)
-          sslEngine.setSSLParameters(params)
+          sslEngine.getHandshakeSession.putValue(peerIdKey, id)
       }
     }
 


### PR DESCRIPTION
Fixes a hack in tls peergroup used to pass client peer id to other parts of the code. 

Main gain from it is, that now upgrading to tls 1.3 is just a question of upgrading netty and putting native tls libraries on class path. (without this fix native libraries throwed exception during handshake)