### PR TITLE
PM-[1860,2396]: Use scala-logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 *.iml
 scalafmt
 .DS_Store
+.metals
+.bloop
+mill.isGc

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.0"
 project.git = true
 maxColumn = 120
 align=none

--- a/build.sc
+++ b/build.sc
@@ -39,9 +39,10 @@ object scalanet extends ScalaModule with PublishModule {
   )
 
   override def ivyDeps = Agg(
-    ivy"io.monix::monix:3.0.0",
+    ivy"io.monix::monix:3.1.0",
     ivy"com.github.nscala-time::nscala-time:2.22.0",
     ivy"com.chuusai::shapeless:2.3.3",
+    ivy"com.typesafe.scala-logging::scala-logging:3.9.2",
     ivy"org.slf4j:slf4j-api:1.7.25",
     ivy"io.netty:netty-all:4.1.31.Final",
     ivy"org.eclipse.californium:scandium:2.0.0-M15",

--- a/build.sc
+++ b/build.sc
@@ -39,7 +39,7 @@ object scalanet extends ScalaModule with PublishModule {
   )
 
   override def ivyDeps = Agg(
-    ivy"io.monix::monix:3.1.0",
+    ivy"io.monix::monix:3.2.2",
     ivy"com.github.nscala-time::nscala-time:2.22.0",
     ivy"com.chuusai::shapeless:2.3.3",
     ivy"com.typesafe.scala-logging::scala-logging:3.9.2",
@@ -107,7 +107,7 @@ object scalanet extends ScalaModule with PublishModule {
       ivy"com.github.pureconfig::pureconfig:0.11.1",
       ivy"com.github.scopt::scopt:3.7.1",
       ivy"org.scodec::scodec-bits:1.1.6",
-      ivy"io.monix::monix:3.0.0",
+      ivy"io.monix::monix:3.2.2",
       ivy"org.scala-lang.modules::scala-parser-combinators:1.1.2"
     )
 

--- a/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
@@ -145,8 +145,8 @@ class KademliaIntegrationSpec extends AsyncFlatSpec with BeforeAndAfterAll with 
     println(nodesRound2)
     for {
       node <- startNode()
-      node1 <- Task.wanderUnordered(nodesRound1)(n => startNode(n, initialNodes = Set(node.self)))
-      node2 <- Task.wanderUnordered(nodesRound2)(n => startNode(n, initialNodes = Set(node.self)))
+      node1 <- Task.parTraverseUnordered(nodesRound1)(n => startNode(n, initialNodes = Set(node.self)))
+      node2 <- Task.parTraverseUnordered(nodesRound2)(n => startNode(n, initialNodes = Set(node.self)))
     } yield {
       eventually {
         node.getPeers.runSyncUnsafe().size shouldEqual 11

--- a/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
@@ -236,9 +236,9 @@ class UDPPeerGroup[M](val config: Config)(
 
     private def closeChannel(): Task[Unit] = {
       for {
-        _ <- Task.delay(logger.debug("Closing channel from {} to {}", localAddress: Any, remoteAddress: Any))
+        _ <- Task(logger.debug("Closing channel from {} to {}", localAddress: Any, remoteAddress: Any))
         _ <- closeNettyChannel(channelType)
-        _ <- Task.delay(logger.debug("Channel from {} to {} closed", localAddress: Any, remoteAddress: Any))
+        _ <- Task(logger.debug("Channel from {} to {} closed", localAddress: Any, remoteAddress: Any))
       } yield ()
     }
 
@@ -256,7 +256,7 @@ class UDPPeerGroup[M](val config: Config)(
         recipient: InetSocketAddress,
         nettyChannel: NioDatagramChannel
     ): Task[Unit] = {
-      Task.delay(logger.debug("Sending message {} to peer {}", message, recipient)) *>
+      Task(logger.debug("Sending message {} to peer {}", message, recipient)) *>
         Task.fromTry(codec.encode(message).toTry).flatMap { encodedMessage =>
           val asBuffer = encodedMessage.toByteBuffer
           toTask(nettyChannel.writeAndFlush(new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), recipient, sender)))
@@ -273,7 +273,7 @@ class UDPPeerGroup[M](val config: Config)(
   override def initialize(): Task[Unit] =
     toTask(serverBind).onErrorRecoverWith {
       case NonFatal(e) => Task.raiseError(InitializationError(e.getMessage, e.getCause))
-    } *> Task.delay(logger.info(s"Server bound to address ${config.bindAddress}"))
+    } *> Task(logger.info(s"Server bound to address ${config.bindAddress}"))
 
   override def processAddress: InetMultiAddress = config.processAddress
 
@@ -298,7 +298,7 @@ class UDPPeerGroup[M](val config: Config)(
       }
       .onErrorRecoverWith {
         case e: Throwable =>
-          Task.delay(logger.debug("Udp channel setup failed due to {}", e)) *>
+          Task(logger.debug("Udp channel setup failed due to {}", e)) *>
             Task.raiseError(new ChannelSetupException[InetMultiAddress](to, e))
       }
   }

--- a/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
@@ -4,6 +4,9 @@ import java.io.IOException
 import java.net.{InetSocketAddress, PortUnreachableException}
 import java.util.concurrent.ConcurrentHashMap
 
+import cats.syntax.apply._
+import cats.syntax.functor._
+import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.monix_subject.ConnectableSubject
 import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, DecodingError, MessageReceived, UnexpectedError}
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
@@ -23,7 +26,6 @@ import io.netty.util.concurrent.{Future, GenericFutureListener, Promise}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.observables.ConnectableObservable
-import org.slf4j.LoggerFactory
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec}
 import scala.util.control.NonFatal
@@ -38,9 +40,8 @@ import scala.util.control.NonFatal
 class UDPPeerGroup[M](val config: Config)(
     implicit codec: Codec[M],
     scheduler: Scheduler
-) extends TerminalPeerGroup[InetMultiAddress, M]() {
-
-  private val log = LoggerFactory.getLogger(getClass)
+) extends TerminalPeerGroup[InetMultiAddress, M]()
+    with StrictLogging {
 
   val serverSubject = ConnectableSubject[ServerEvent[InetMultiAddress, M]]()
 
@@ -73,7 +74,7 @@ class UDPPeerGroup[M](val config: Config)(
       case Attempt.Successful(msg) =>
         channel.messageSubject.onNext(MessageReceived(msg))
       case Attempt.Failure(er) =>
-        log.debug("Message decoding failed due to {}", er)
+        logger.debug("Message decoding failed due to {}", er)
         channel.messageSubject.onNext(DecodingError)
     }
   }
@@ -81,7 +82,7 @@ class UDPPeerGroup[M](val config: Config)(
   private def handleError(channelId: UdpChannelId, error: Throwable): Unit = {
     // Inform about error only if channel is available and open
     Option(activeChannels.get(channelId)).foreach { ch =>
-      log.debug("Unexpected error {} on channel {}", error: Any, channelId: Any)
+      logger.debug("Unexpected error {} on channel {}", error: Any, channelId: Any)
       ch.messageSubject.onNext(UnexpectedError(error))
     }
   }
@@ -105,7 +106,7 @@ class UDPPeerGroup[M](val config: Config)(
               val localAddress = datagram.recipient()
               val udpChannelId = UdpChannelId(ctx.channel().id(), remoteAddress, localAddress)
               try {
-                log.info(s"Client channel read message with remote $remoteAddress and local $localAddress")
+                logger.info(s"Client channel read message with remote $remoteAddress and local $localAddress")
                 Option(activeChannels.get(udpChannelId)).foreach(handleIncomingMessage(_, datagram))
               } catch {
                 case NonFatal(e) => handleError(udpChannelId, e)
@@ -123,7 +124,7 @@ class UDPPeerGroup[M](val config: Config)(
                 case _: PortUnreachableException =>
                   // we do not want ugly exception, but we do not close the channel, it is entirely up to user to close not
                   // responding channels
-                  log.info("Peer with ip {} not available", remoteAddress)
+                  logger.info("Peer with ip {} not available", remoteAddress)
 
                 case _ =>
                   super.exceptionCaught(ctx, cause)
@@ -147,7 +148,7 @@ class UDPPeerGroup[M](val config: Config)(
               val datagram = msg.asInstanceOf[DatagramPacket]
               val remoteAddress = datagram.sender()
               val localAddress = datagram.recipient()
-              log.info(s"Server from $remoteAddress")
+              logger.info(s"Server from $remoteAddress")
               val serverChannel: NioDatagramChannel = ctx.channel().asInstanceOf[NioDatagramChannel]
               val potentialNewChannel = new ChannelImpl(
                 serverChannel,
@@ -161,7 +162,7 @@ class UDPPeerGroup[M](val config: Config)(
                   case Some(existingChannel) =>
                     handleIncomingMessage(existingChannel, datagram)
                   case None =>
-                    log.debug(
+                    logger.debug(
                       s"Channel with id ${potentialNewChannel.channelId}. NOT found in active channels table. Creating a new one"
                     )
                     potentialNewChannel.closePromise.addListener(closeChannelListener)
@@ -177,7 +178,7 @@ class UDPPeerGroup[M](val config: Config)(
 
             override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
               // We cannot create UdpChannelId as on udp netty server channel there is no remote peer address.
-              log.error(s"Unexpected server error ${cause.getMessage}")
+              logger.error(s"Unexpected server error ${cause.getMessage}")
             }
           })
       }
@@ -195,7 +196,7 @@ class UDPPeerGroup[M](val config: Config)(
 
     val channelId = UdpChannelId(nettyChannel.id(), remoteAddress, localAddress)
 
-    log.debug(
+    logger.debug(
       s"Setting up new channel from local address $localAddress " +
         s"to remote address $remoteAddress. Netty channelId is ${nettyChannel.id()}. " +
         s"My channelId is ${channelId}"
@@ -235,9 +236,9 @@ class UDPPeerGroup[M](val config: Config)(
 
     private def closeChannel(): Task[Unit] = {
       for {
-        _ <- Task.now(log.debug("Closing channel from {} to {}", localAddress: Any, remoteAddress: Any))
+        _ <- Task.delay(logger.debug("Closing channel from {} to {}", localAddress: Any, remoteAddress: Any))
         _ <- closeNettyChannel(channelType)
-        _ <- Task.now(log.debug("Channel from {} to {} closed", localAddress: Any, remoteAddress: Any))
+        _ <- Task.delay(logger.debug("Channel from {} to {} closed", localAddress: Any, remoteAddress: Any))
       } yield ()
     }
 
@@ -255,33 +256,33 @@ class UDPPeerGroup[M](val config: Config)(
         recipient: InetSocketAddress,
         nettyChannel: NioDatagramChannel
     ): Task[Unit] = {
-      log.debug("Sending message {} to peer {}", message, recipient)
-      Task.fromTry(codec.encode(message).toTry).flatMap { encodedMessage =>
-        val asBuffer = encodedMessage.toByteBuffer
-        toTask(nettyChannel.writeAndFlush(new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), recipient, sender)))
-          .onErrorRecoverWith {
-            case _: IOException =>
-              Task.raiseError(new MessageMTUException[InetMultiAddress](to, asBuffer.capacity()))
-          }
-      }
+      Task.delay(logger.debug("Sending message {} to peer {}", message, recipient)) *>
+        Task.fromTry(codec.encode(message).toTry).flatMap { encodedMessage =>
+          val asBuffer = encodedMessage.toByteBuffer
+          toTask(nettyChannel.writeAndFlush(new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), recipient, sender)))
+            .onErrorRecoverWith {
+              case _: IOException =>
+                Task.raiseError(new MessageMTUException[InetMultiAddress](to, asBuffer.capacity()))
+            }
+        }
     }
   }
 
   private lazy val serverBind: ChannelFuture = serverBootstrap.bind(config.bindAddress)
 
   override def initialize(): Task[Unit] =
-    toTask(serverBind).map(_ => log.info(s"Server bound to address ${config.bindAddress}")).onErrorRecoverWith {
+    toTask(serverBind).onErrorRecoverWith {
       case NonFatal(e) => Task.raiseError(InitializationError(e.getMessage, e.getCause))
-    }
+    } *> Task.delay(logger.info(s"Server bound to address ${config.bindAddress}"))
 
   override def processAddress: InetMultiAddress = config.processAddress
 
   override def client(to: InetMultiAddress): Task[Channel[InetMultiAddress, M]] = {
     val cf = clientBootstrap.connect(to.inetSocketAddress)
-    val ct: Task[NioDatagramChannel] = toTask(cf).map(_ => cf.channel().asInstanceOf[NioDatagramChannel])
+    val ct: Task[NioDatagramChannel] = toTask(cf).as(cf.channel().asInstanceOf[NioDatagramChannel])
     ct.map { nettyChannel =>
         val localAddress = nettyChannel.localAddress()
-        log.debug(s"Generated local address for new client is $localAddress")
+        logger.debug(s"Generated local address for new client is $localAddress")
         val channel = new ChannelImpl(
           nettyChannel,
           localAddress,
@@ -297,8 +298,8 @@ class UDPPeerGroup[M](val config: Config)(
       }
       .onErrorRecoverWith {
         case e: Throwable =>
-          log.debug("Udp channel setup failed due to {}", e)
-          Task.raiseError(new ChannelSetupException[InetMultiAddress](to, e))
+          Task.delay(logger.debug("Udp channel setup failed due to {}", e)) *>
+            Task.raiseError(new ChannelSetupException[InetMultiAddress](to, e))
       }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/UDPPeerGroup.scala
@@ -4,7 +4,6 @@ import java.io.IOException
 import java.net.{InetSocketAddress, PortUnreachableException}
 import java.util.concurrent.ConcurrentHashMap
 
-import cats.syntax.apply._
 import cats.syntax.functor._
 import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.monix_subject.ConnectableSubject

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -4,7 +4,6 @@ import java.net.InetSocketAddress
 import java.security._
 import java.security.cert.X509Certificate
 
-import cats.syntax.apply._
 import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.crypto.CryptoUtils

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -4,6 +4,8 @@ import java.net.InetSocketAddress
 import java.security._
 import java.security.cert.X509Certificate
 
+import cats.syntax.apply._
+import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.crypto.CryptoUtils
 import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
@@ -27,7 +29,6 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.observables.ConnectableObservable
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-import org.slf4j.LoggerFactory
 import scodec.bits.BitVector
 
 import scala.util.Try
@@ -46,9 +47,8 @@ import scala.util.control.NonFatal
 class DynamicTLSPeerGroup[M](val config: Config)(
     implicit codec: StreamCodec[M],
     scheduler: Scheduler
-) extends TerminalPeerGroup[PeerInfo, M]() {
-
-  private val log = LoggerFactory.getLogger(getClass)
+) extends TerminalPeerGroup[PeerInfo, M]()
+    with StrictLogging {
 
   private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForServer, config)
 
@@ -70,7 +70,7 @@ class DynamicTLSPeerGroup[M](val config: Config)(
     .childHandler(new ChannelInitializer[SocketChannel]() {
       override def initChannel(ch: SocketChannel): Unit = {
         new ServerChannelBuilder[M](serverSubject, ch, sslServerCtx, codec.cleanSlate)
-        log.info(s"$processAddress received inbound from ${ch.remoteAddress()}.")
+        logger.info(s"$processAddress received inbound from ${ch.remoteAddress()}.")
       }
     })
     .option[Integer](ChannelOption.SO_BACKLOG, 128)
@@ -80,9 +80,9 @@ class DynamicTLSPeerGroup[M](val config: Config)(
   private lazy val serverBind: ChannelFuture = serverBootstrap.bind(config.bindAddress)
 
   override def initialize(): Task[Unit] =
-    toTask(serverBind).map(_ => log.info(s"Server bound to address ${config.bindAddress}")).onErrorRecoverWith {
+    toTask(serverBind).onErrorRecoverWith {
       case NonFatal(e) => Task.raiseError(InitializationError(e.getMessage, e.getCause))
-    }
+    } *> Task.delay(logger.info(s"Server bound to address ${config.bindAddress}"))
 
   override def processAddress: PeerInfo = config.peerInfo
 
@@ -103,11 +103,11 @@ class DynamicTLSPeerGroup[M](val config: Config)(
 
   override def shutdown(): Task[Unit] = {
     for {
-      _ <- Task.now(log.debug("Start shutdown of tls peer group for peer {}", processAddress))
+      _ <- Task.delay(logger.debug("Start shutdown of tls peer group for peer {}", processAddress))
       _ <- Task(serverSubject.onComplete())
       _ <- toTask(serverBind.channel().close())
       _ <- toTask(workerGroup.shutdownGracefully())
-      _ <- Task.now(log.debug("Tls peer group shutdown for peer {}", processAddress))
+      _ <- Task.delay(logger.debug("Tls peer group shutdown for peer {}", processAddress))
     } yield ()
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -82,7 +82,7 @@ class DynamicTLSPeerGroup[M](val config: Config)(
   override def initialize(): Task[Unit] =
     toTask(serverBind).onErrorRecoverWith {
       case NonFatal(e) => Task.raiseError(InitializationError(e.getMessage, e.getCause))
-    } *> Task.delay(logger.info(s"Server bound to address ${config.bindAddress}"))
+    } *> Task(logger.info(s"Server bound to address ${config.bindAddress}"))
 
   override def processAddress: PeerInfo = config.peerInfo
 
@@ -103,11 +103,11 @@ class DynamicTLSPeerGroup[M](val config: Config)(
 
   override def shutdown(): Task[Unit] = {
     for {
-      _ <- Task.delay(logger.debug("Start shutdown of tls peer group for peer {}", processAddress))
+      _ <- Task(logger.debug("Start shutdown of tls peer group for peer {}", processAddress))
       _ <- Task(serverSubject.onComplete())
       _ <- toTask(serverBind.channel().close())
       _ <- toTask(workerGroup.shutdownGracefully())
-      _ <- Task.delay(logger.debug("Tls peer group shutdown for peer {}", processAddress))
+      _ <- Task(logger.debug("Tls peer group shutdown for peer {}", processAddress))
     } yield ()
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -151,10 +151,10 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
 
     def initialize: Task[ClientChannelImpl[M]] = {
       val connectTask = for {
-        _ <- Task.delay(logger.debug("Initiating connection to peer {}", peerInfo))
+        _ <- Task(logger.debug("Initiating connection to peer {}", peerInfo))
         _ <- toTask(bootstrap.connect(peerInfo.address.inetSocketAddress))
         _ <- Task.fromFuture(activationF)
-        _ <- Task.delay(logger.debug("Connection to peer {} finished successfully", peerInfo))
+        _ <- Task(logger.debug("Connection to peer {} finished successfully", peerInfo))
       } yield this
 
       connectTask.onErrorRecoverWith {
@@ -166,7 +166,7 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
     override def sendMessage(message: M): Task[Unit] = {
       val sendTask = for {
         channel <- Task.fromFuture(activationF)
-        _ <- Task.delay(
+        _ <- Task(
           logger.debug(
             s"Processing outbound message from local address ${channel.localAddress()} " +
               s"to remote address ${channel.remoteAddress()} via channel id ${channel.id()}"
@@ -177,7 +177,7 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
 
       sendTask.onErrorRecoverWith {
         case e: IOException =>
-          Task.delay(logger.debug("Sending message to {} failed due to {}", peerInfo: Any, e: Any)) *>
+          Task(logger.debug("Sending message to {} failed due to {}", peerInfo: Any, e: Any)) *>
             Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
       }
     }
@@ -190,11 +190,11 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       */
     override def close(): Task[Unit] = {
       for {
-        _ <- Task.delay(logger.debug("Closing client channel to peer {}", peerInfo))
+        _ <- Task(logger.debug("Closing client channel to peer {}", peerInfo))
         ctx <- Task.fromFuture(activationF)
         _ <- toTask(ctx.close())
         _ <- toTask(ctx.closeFuture())
-        _ <- Task.delay(logger.debug("Client channel to peer {} closed", peerInfo))
+        _ <- Task(logger.debug("Client channel to peer {} closed", peerInfo))
       } yield ()
     }
   }
@@ -283,10 +283,10 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       */
     override def close(): Task[Unit] =
       for {
-        _ <- Task.delay(logger.debug("Closing server channel to peer {}", to))
+        _ <- Task(logger.debug("Closing server channel to peer {}", to))
         _ <- toTask(nettyChannel.close())
         _ <- toTask(nettyChannel.closeFuture())
-        _ <- Task.delay(logger.debug("Server channel to peer {} closed", to))
+        _ <- Task(logger.debug("Server channel to peer {} closed", to))
       } yield ()
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -4,6 +4,8 @@ import java.io.IOException
 import java.net.{ConnectException, InetSocketAddress}
 import java.nio.channels.ClosedChannelException
 
+import cats.syntax.apply._
+import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.monix_subject.ConnectableSubject
 import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, DecodingError, MessageReceived, UnexpectedError}
@@ -21,7 +23,6 @@ import javax.net.ssl.{SSLException, SSLHandshakeException, SSLKeyException}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.observables.ConnectableObservable
-import org.slf4j.LoggerFactory
 import scodec.bits.BitVector
 
 import scala.concurrent.Promise
@@ -39,12 +40,11 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
   class MessageNotifier[M](
       val messageSubject: ConnectableSubject[ChannelEvent[M]],
       codec: StreamCodec[M]
-  ) extends ChannelInboundHandlerAdapter {
-
-    private val log = LoggerFactory.getLogger(getClass)
+  ) extends ChannelInboundHandlerAdapter
+      with StrictLogging {
 
     override def channelInactive(channelHandlerContext: ChannelHandlerContext): Unit = {
-      log.debug("Channel to peer {} inactive", channelHandlerContext.channel().remoteAddress())
+      logger.debug("Channel to peer {} inactive", channelHandlerContext.channel().remoteAddress())
       messageSubject.onComplete()
     }
 
@@ -53,12 +53,12 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       try {
         codec.streamDecode(BitVector(byteBuf.nioBuffer())) match {
           case Left(value) =>
-            log.error("Unexpected decoding error {} from peer {}", value: Any, ctx.channel().remoteAddress(): Any)
+            logger.error("Unexpected decoding error {} from peer {}", value: Any, ctx.channel().remoteAddress(): Any)
             messageSubject.onNext(DecodingError)
 
           case Right(value) =>
             value.foreach { m =>
-              log.debug("Decoded new message from peer {}", ctx.channel().remoteAddress())
+              logger.debug("Decoded new message from peer {}", ctx.channel().remoteAddress())
               messageSubject.onNext(MessageReceived(m))
             }
         }
@@ -71,7 +71,7 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
 
     override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
       // swallow netty's default logging of the stack trace.
-      log.debug(
+      logger.error(
         "Unexpected exception {} on channel to peer {}",
         cause.getMessage: Any,
         ctx.channel().remoteAddress(): Any
@@ -86,9 +86,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       sslClientCtx: SslContext,
       codec: StreamCodec[M]
   )(implicit scheduler: Scheduler)
-      extends Channel[PeerInfo, M] {
-
-    private val log = LoggerFactory.getLogger(getClass)
+      extends Channel[PeerInfo, M]
+      with StrictLogging {
 
     val to: PeerInfo = peerInfo
 
@@ -101,7 +100,7 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       .clone()
       .handler(new ChannelInitializer[SocketChannel]() {
         def initChannel(ch: SocketChannel): Unit = {
-          log.debug("Initiating connection to peer {}", peerInfo)
+          logger.debug("Initiating connection to peer {}", peerInfo)
           val pipeline = ch.pipeline()
           val sslHandler = sslClientCtx.newHandler(ch.alloc())
 
@@ -111,20 +110,20 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
               override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any): Unit = {
                 evt match {
                   case e: SslHandshakeCompletionEvent =>
-                    log.info(
+                    logger.info(
                       s"Ssl Handshake client channel from ${ctx.channel().localAddress()} " +
                         s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
                     )
                     if (e.isSuccess) {
-                      log.debug("Handshake to peer {} succeeded", peerInfo)
+                      logger.debug("Handshake to peer {} succeeded", peerInfo)
                       activation.success(ctx.channel())
                     } else {
-                      log.debug("Handshake to peer {} failed due to {}", peerInfo, e: Any)
+                      logger.debug("Handshake to peer {} failed due to {}", peerInfo, e: Any)
                       activation.failure(e.cause())
                     }
 
                   case ev =>
-                    log.debug(
+                    logger.debug(
                       s"User Event $ev on client channel from ${ctx.channel().localAddress()} " +
                         s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id}"
                     )
@@ -152,10 +151,10 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
 
     def initialize: Task[ClientChannelImpl[M]] = {
       val connectTask = for {
-        _ <- Task.now(log.debug("Initiating connection to peer {}", peerInfo))
+        _ <- Task.delay(logger.debug("Initiating connection to peer {}", peerInfo))
         _ <- toTask(bootstrap.connect(peerInfo.address.inetSocketAddress))
         _ <- Task.fromFuture(activationF)
-        _ <- Task.now(log.debug("Connection to peer {} finished successfully", peerInfo))
+        _ <- Task.delay(logger.debug("Connection to peer {} finished successfully", peerInfo))
       } yield this
 
       connectTask.onErrorRecoverWith {
@@ -167,8 +166,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
     override def sendMessage(message: M): Task[Unit] = {
       val sendTask = for {
         channel <- Task.fromFuture(activationF)
-        _ <- Task.now(
-          log.debug(
+        _ <- Task.delay(
+          logger.debug(
             s"Processing outbound message from local address ${channel.localAddress()} " +
               s"to remote address ${channel.remoteAddress()} via channel id ${channel.id()}"
           )
@@ -178,8 +177,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
 
       sendTask.onErrorRecoverWith {
         case e: IOException =>
-          log.debug("Sending message to {} failed due to {}", peerInfo: Any, e: Any)
-          Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
+          Task.delay(logger.debug("Sending message to {} failed due to {}", peerInfo: Any, e: Any)) *>
+            Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
       }
     }
 
@@ -191,11 +190,11 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       */
     override def close(): Task[Unit] = {
       for {
-        _ <- Task.now(log.debug("Closing client channel to peer {}", peerInfo))
+        _ <- Task.delay(logger.debug("Closing client channel to peer {}", peerInfo))
         ctx <- Task.fromFuture(activationF)
         _ <- toTask(ctx.close())
         _ <- toTask(ctx.closeFuture())
-        _ <- Task.now(log.debug("Client channel to peer {} closed", peerInfo))
+        _ <- Task.delay(logger.debug("Client channel to peer {} closed", peerInfo))
       } yield ()
     }
   }
@@ -205,8 +204,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       val nettyChannel: SocketChannel,
       sslServerCtx: SslContext,
       codec: StreamCodec[M]
-  )(implicit scheduler: Scheduler) {
-    private val log = LoggerFactory.getLogger(getClass)
+  )(implicit scheduler: Scheduler)
+      extends StrictLogging {
     val sslHandler = sslServerCtx.newHandler(nettyChannel.alloc())
 
     val messageSubject = ConnectableSubject[ChannelEvent[M]]()
@@ -226,14 +225,14 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
                 // to be called to put value in session, but after handshake sslEngine.getSession needs to be called
                 // get the same session with value
                 val peerId = sslEngine.getSession.getValue(DynamicTLSPeerGroupUtils.peerIdKey).asInstanceOf[BitVector]
-                log.debug(
+                logger.debug(
                   s"Ssl Handshake server channel from $localAddress " +
                     s"to $remoteAddress with channel id ${ctx.channel().id} and ssl status ${e.isSuccess}"
                 )
                 val channel = new ServerChannelImpl[M](nettyChannel, peerId, codec, messageSubject)
                 serverSubject.onNext(ChannelCreated(channel))
               } else {
-                log.debug("Ssl handshake failed from peer with address {}", remoteAddress)
+                logger.debug("Ssl handshake failed from peer with address {}", remoteAddress)
                 // Handshake failed we do not have id of remote peer
                 serverSubject
                   .onNext(
@@ -242,7 +241,7 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
                   )
               }
             case ev =>
-              log.debug(
+              logger.debug(
                 s"User Event $ev on server channel from ${ctx.channel().localAddress()} " +
                   s"to ${ctx.channel().remoteAddress()} with channel id ${ctx.channel().id}"
               )
@@ -258,21 +257,20 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       codec: StreamCodec[M],
       messageSubject: ConnectableSubject[ChannelEvent[M]]
   )(implicit scheduler: Scheduler)
-      extends Channel[PeerInfo, M] {
+      extends Channel[PeerInfo, M]
+      with StrictLogging {
 
-    private val log = LoggerFactory.getLogger(getClass)
-
-    log.debug(
+    logger.debug(
       s"Creating server channel from ${nettyChannel.localAddress()} to ${nettyChannel.remoteAddress()} with channel id ${nettyChannel.id}"
     )
 
     override val to: PeerInfo = PeerInfo(peerId, InetMultiAddress(nettyChannel.remoteAddress()))
 
     override def sendMessage(message: M): Task[Unit] = {
-      log.debug("Sending message to peer {} via server channel", nettyChannel.localAddress())
+      logger.debug("Sending message to peer {} via server channel", nettyChannel.localAddress())
       nettyChannel.sendMessage(message)(codec).onErrorRecoverWith {
         case e: IOException =>
-          log.debug("Sending message to {} failed due to {}", message, e)
+          logger.debug("Sending message to {} failed due to {}", message, e)
           Task.raiseError(new ChannelBrokenException[PeerInfo](to, e))
       }
     }
@@ -285,10 +283,10 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
       */
     override def close(): Task[Unit] =
       for {
-        _ <- Task.now(log.debug("Closing server channel to peer {}", to))
+        _ <- Task.delay(logger.debug("Closing server channel to peer {}", to))
         _ <- toTask(nettyChannel.close())
         _ <- toTask(nettyChannel.closeFuture())
-        _ <- Task.now(log.debug("Server channel to peer {} closed", to))
+        _ <- Task.delay(logger.debug("Server channel to peer {} closed", to))
       } yield ()
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -4,7 +4,6 @@ import java.io.IOException
 import java.net.{ConnectException, InetSocketAddress}
 import java.nio.channels.ClosedChannelException
 
-import cats.syntax.apply._
 import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.monix_subject.ConnectableSubject

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -331,7 +331,7 @@ class KRouter[A](
         case false =>
           val (toQuery, rest) = nodesToQuery.splitAt(config.alpha)
           for {
-            queryResults <- Task.wander(toQuery) { knownNode =>
+            queryResults <- Task.parTraverse(toQuery) { knownNode =>
               handleQuery(knownNode)
             }
 
@@ -366,7 +366,7 @@ class KRouter[A](
           // All initial nodes are scheduled to request
           state <- Ref.of[Task, Map[BitVector, RequestResult]](initalRequestState)
           // closestKnownNodes are constrained by alpha, it means there will be at most alpha independent recursive tasks
-          results <- Task.wander(closestKnownNodes) { knownNode =>
+          results <- Task.parTraverse(closestKnownNodes) { knownNode =>
             recLookUp(List(knownNode), NonEmptyList.fromListUnsafe(closestKnownNodes.toList), state)
           }
           records = results.flatMap(_.toList)

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
@@ -73,7 +73,7 @@ class TransportPeerGroupAsyncSpec extends AsyncFlatSpec with BeforeAndAfterAll {
           client3.send(k, client1.processAddress)
         )
         (r1, r2, r3) = responses
-        responses <- Task.gather((1 to 4).map { req =>
+        responses <- Task.parSequence((1 to 4).map { req =>
           if (req % 2 == 0) {
             client1.send(req, client3.processAddress)
           } else {


### PR DESCRIPTION
Instead of using the `slf4j.Logger` interface directly, use [scala-logging](https://github.com/lightbend/scala-logging). The benefit is that if the DEBUG level is not enabled then the macros won't evaluate the arguments.

Wrapped logs in `Task.delay` where it was `Task.now` so that we get referential transparency. `Task.now(logger.info(...))` would emit the log as a side effect of creating the task, but `.delay` suspends it. 

`import cats.syntax.apply._` is to get access to the `task1 *> task2` syntax which is part of monix 3.2.2, but not 3.0.0. Updated to 3.1.0 for now since that's what the downstream project is using, and updating to 3.2.2 would cause `Task.gather` and `Task.wander` to be deprecated. But I think we should upgrade to 3.2.2 to get any bug fixes.

We agreed with @KonradStaniec to do this as part of the tickets mentioned in the title, but the actual fixes they refer to will come separately.