### PR TITLE
PM-1860: Sanitize peers before logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scalafmt
 .metals
 .bloop
 mill.isGc
+.vscode

--- a/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/it/src/io/iohk/scalanet/peergroup/kademlia/KademliaIntegrationSpec.scala
@@ -27,7 +27,9 @@ class KademliaIntegrationSpec extends AsyncFlatSpec with BeforeAndAfterAll with 
     threadPool.awaitTermination(60, TimeUnit.SECONDS)
   }
 
-  "Kademlia" should "only find self node when there are no bootstrap nodes" in taskTestCase {
+  behavior of "Kademlia"
+
+  it should "only find self node when there are no bootstrap nodes" in taskTestCase {
     for {
       node <- startNode()
       knownNodes <- node.router.nodeRecords
@@ -173,8 +175,8 @@ class KademliaIntegrationSpec extends AsyncFlatSpec with BeforeAndAfterAll with 
 
       eventually {
         val peers = rootNode.getPeers.runSyncUnsafe()
-        peers.contains(rest.last) shouldBe false
-        peers.size shouldEqual 4
+        peers should have size 4
+        peers should not contain rest.last
       }
     }
   }

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -400,12 +400,11 @@ class KRouter[A](
     if (nodeRecords.isEmpty) {
       s"Lookup to ${targetNodeId.toHex} returned no results."
     } else {
-      val ids = nodeRecords.toSeq.map(_.id).reverse
-
-      val ds: Map[BitVector, (NodeRecord[A], BigInt)] =
-        nodeRecords.map(nodeRecord => (nodeRecord.id, (nodeRecord, Xor.d(nodeRecord.id, targetNodeId)))).toMap
-
-      val rep = ids.map(nodeId => ds(nodeId)).mkString("\n| ")
+      val rep = nodeRecords.toSeq
+        .map { node =>
+          node -> Xor.d(node.id, targetNodeId)
+        }
+        .mkString("\n| ")
 
       s"""
          | Lookup to target ${targetNodeId.toHex} returned

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -339,7 +339,7 @@ class KRouter[A](
         case false =>
           val (toQuery, rest) = nodesToQuery.splitAt(config.alpha)
           for {
-            queryResults <- Task.parTraverse(toQuery) { knownNode =>
+            queryResults <- Task.parTraverseUnordered(toQuery) { knownNode =>
               handleQuery(knownNode)
             }
 
@@ -379,7 +379,7 @@ class KRouter[A](
             // All initial nodes are scheduled to request
             state <- Ref.of[Task, Map[BitVector, RequestResult]](initalRequestState)
             // closestKnownNodes are constrained by alpha, it means there will be at most alpha independent recursive tasks
-            results <- Task.parTraverse(closestKnownNodes.toList) { knownNode =>
+            results <- Task.parTraverseUnordered(closestKnownNodes.toList) { knownNode =>
               recLookUp(List(knownNode), closestKnownNodes, state)
             }
             records = results.reduce(_ ++ _).toSortedSet

--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -400,7 +400,8 @@ class KRouter[A](
     if (nodeRecords.isEmpty) {
       s"Lookup to ${targetNodeId.toHex} returned no results."
     } else {
-      val rep = nodeRecords.toSeq
+      // Print distances in descending order.
+      val rep = nodeRecords.toSeq.reverse
         .map { node =>
           node -> Xor.d(node.id, targetNodeId)
         }


### PR DESCRIPTION
The problem was that the debug report about lookup results contained duplicates because the algorithm preformed the lookup with the closest nodes in parallel and then just concatenated the results, so if multiple peers knew about the same nodes, they were included repeatedly. 

The PR changes the result of the `lookup` function to be a `Set` rather than a `Seq`. We didn't apply any ordering at that point, so `Set` describes the result better. `lookup` is only used internally, it's followed by a read on the modified local caches, so there are no unit tests for it separately, the log was the only indication of the duplicates.