### PR TITLE
PM-2396: Fix identified peer log

### DIFF
--- a/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/kademlia/KRouter.scala
@@ -104,16 +104,20 @@ class KRouter[A](
     loadKnownPeers.flatMap(_ => lookup(config.nodeRecord.id)).attempt.flatMap {
       case Left(t) =>
         Task {
-          logger.info(s"Enrolment lookup failed with exception: $t")
+          logger.error(s"Enrolment lookup failed with exception: $t")
           logger.debug(s"Enrolment failure stacktrace: ${t.getStackTrace.mkString("\n")}")
           Seq()
         }
       case Right(nodes) =>
         Task {
+          val nodeIds = nodes.map(_.id)
+          val bootIds = config.knownPeers.map(_.id)
+          val countSelf = nodeIds.count(myself)
+          val countBoot = nodeIds.count(bootIds)
           logger.debug(s"Enrolment looked completed with network nodes ${nodes.mkString(",")}")
           logger.info(
             s"Initialization complete. ${nodes.size} peers identified " +
-              s"(of which 1 is myself and ${config.knownPeers.size} are preconfigured bootstrap peers)."
+              s"(of which ${countSelf} is myself and ${countBoot} are among the ${bootIds.size} preconfigured bootstrap peers)."
           )
           nodes
         }


### PR DESCRIPTION
During startup the `KRouter` calls `enroll()` which adds all the bootstrap nodes to the K-table then calls `lookup` with its own ID to discover the closest nodes to it. Upon successful completion it reports the number of peers identified and assumes that itself will be on that list as well as all the configured bootstraps, however that isn't true because if the other nodes haven't seen this one yet, they won't return it, and some of the bootstrap nodes may be offline. 

The PR changes the log to be based on actual counts.