### PR TITLE
ETCM-161: Move the kademlia package into its own submodule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,36 @@ Scalanet is an asynchronous, strongly typed, resource-managed networking library
 What does all that mean?
  * Resource managed. Scalanet makes it as easy as possible to send and receive messages without having to open or close connections.
  * Asynchronous. Scalanet is non-blocking. In this regard, it is like netty, however, unlike netty, Scalanet uses *reactive*
- programming idioms. 
- * Technology support. Out of the box, Scalanet supports TCP and UDP (with other internet and non-internet technologies to come) but through an abstraction called the _Peer Group_, allows for the addition of other transports or more complex p2p overlays (kademlia, ethereum, etc). The _Peer Group_ provides a consistent interface whatever your networking approach.   
+ programming idioms.
+ * Technology support. Out of the box, Scalanet supports TCP and UDP (with other internet and non-internet technologies to come) but through an abstraction called the _Peer Group_, allows for the addition of other transports or more complex p2p overlays (kademlia, ethereum, etc). The _Peer Group_ provides a consistent interface whatever your networking approach.
 
 It is well suited to peer-to-peer apps but supports client-server too.
 
 ### Peer groups
-As mentioned, the foundation of Scalanet is the notion of a _Peer Group_. From a practical standpoint, a peer group 
-allows an application to use a variety of network technologies with a consistent interface. More abstractly, it defines 
-* an address space and 
+As mentioned, the foundation of Scalanet is the notion of a _Peer Group_. From a practical standpoint, a peer group
+allows an application to use a variety of network technologies with a consistent interface. More abstractly, it defines
+* an address space and
 * a context in which communication can happen.
 * TODO: quality of service
 
-A Peer Group could be something like scalanet's `UDPPeerGroup` where the addresses are IP:port combos and the set of 
+A Peer Group could be something like scalanet's `UDPPeerGroup` where the addresses are IP:port combos and the set of
 peers allowed to communicate is basically anybody on the IP network in question (the internet, an office network, etc).
 Equally, a Peer Group could be something like an Ethereum network where addresses are public keys and the peers
 are anybody who talks the RLPx protocol. Equally, a peer group could be an integration test with the address space {Alice, Bob, Charlie}
-and the peers are all in the same JVM. Scalanet will not limit you in this regard. 
+and the peers are all in the same JVM. Scalanet will not limit you in this regard.
 
 Peer groups can implement arbitrary enrolment and encryption schemes, so are suitable for implementing secure messaging overlays.
 Typically, on the internet, limiting the context of communication (aka _zoning_) is performed by firewalls. The idea
 is so ubiquitous that it may not have struck you that this is a hack. Peer groups are designed to support more elegant
 solutions, generally using cryptography instead of firewall provisioning.
- 
+
 ### Structure of the library
 Here is a picture of the structure of the library for a few sample applications:
 ![](doc-resources/sample-configurations.png)
 
 ### Getting started
 The easiest way to get started is to send and receive data over TCP, using the library just like netty. Have a look at
-the [TCPPeerGroupSpec](core/io/iohk/scalanet/test/peergroup/TCPPeerGroupSpec.scala) test case or the following code. 
+the [TCPPeerGroupSpec](core/io/iohk/scalanet/test/peergroup/TCPPeerGroupSpec.scala) test case or the following code.
 
 ```scala
 // import some peer group classes
@@ -62,15 +62,15 @@ val messageF: Future[Unit] = tcp.sendMessage(new InetSocketAddress("example.com"
 
 // receive messages
 tcp.messageStream.foreach((b: ByteBuffer) => ())
- 
-``` 
+
+```
 
 # Contributing
 
 ### Branches
 
-Two main branches are maintained: `develop` and `master`. 
-`master` contains the latest stable version of the library. 
+Two main branches are maintained: `develop` and `master`.
+`master` contains the latest stable version of the library.
 `develop` is the place you want to merge to if submitting PRs.
 
 ### Building the codebase
@@ -80,9 +80,18 @@ To build the codebase, we use [mill](http://www.lihaoyi.com/mill). Assuming you 
 mill __.test
 ```
 
+A single test suite can be executed with the `single` helper command, for example:
+```bash
+mill scalanet.test.single io.iohk.scalanet.crypto.SignatureVerificationSpec
+```
+
+### Publishing
+
+Have a look [here](http://www.lihaoyi.com/mill/page/common-project-layouts.html#publishing) for how to publish multiple modules.
+
 ### Formatting the codebase
 In order to keep the code format consistent, we use scalafmt.
- 
+
 The CI build will fail if code is not formatted, but the project contains a githook that means you do not have to think
 about. To set this up:
 - Install [coursier](https://github.com/coursier/coursier#command-line), the `coursier` command must work.

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/App.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/App.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 import io.iohk.scalanet.kconsole.Utils.{configToStr, generateRandomConfig}
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter
+import io.iohk.scalanet.kademlia.KRouter
 import monix.execution.Scheduler.Implicits.global
 import scopt.OptionParser
 

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
@@ -1,14 +1,14 @@
 package io.iohk.scalanet.kconsole
 
 import io.iohk.scalanet.peergroup.{InetMultiAddress, PeerGroup, UDPPeerGroup}
-import io.iohk.scalanet.peergroup.kademlia.KNetwork.KNetworkScalanetImpl
-import io.iohk.scalanet.peergroup.kademlia.{KMessage, KRouter}
+import io.iohk.scalanet.kademlia.KNetwork.KNetworkScalanetImpl
+import io.iohk.scalanet.kademlia.{KMessage, KRouter}
 import monix.execution.Scheduler
 
 class AppContext(nodeConfig: KRouter.Config[InetMultiAddress])(implicit scheduler: Scheduler) {
   import scodec.codecs.implicits._
-  import io.iohk.scalanet.codec.DefaultCodecs.KademliaMessages._
-  import io.iohk.scalanet.codec.DefaultCodecs.General._
+  import io.iohk.scalanet.codec.DefaultCodecs._
+  import io.iohk.scalanet.kademlia.codec.DefaultCodecs._
 
   val kRouter: KRouter[InetMultiAddress] = {
 

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/CommandParser.scala
@@ -2,8 +2,8 @@ package io.iohk.scalanet.kconsole
 
 import io.iohk.scalanet.kconsole.Utils.parseRecord
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import scodec.bits.BitVector
 
 import scala.concurrent.{Await, Promise}

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/ConsoleLoop.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/ConsoleLoop.scala
@@ -1,7 +1,7 @@
 package io.iohk.scalanet.kconsole
 
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter
+import io.iohk.scalanet.kademlia.KRouter
 
 import scala.io.StdIn
 

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/PureConfigReadersAndWriters.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/PureConfigReadersAndWriters.scala
@@ -3,7 +3,7 @@ package io.iohk.scalanet.kconsole
 import java.net.{InetSocketAddress, URI}
 
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import pureconfig.{ConfigReader, ConfigWriter}
 import pureconfig.ConvertHelpers.catchReadError
 import pureconfig.configurable.{genericMapReader, genericMapWriter}

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/Utils.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/Utils.scala
@@ -3,8 +3,8 @@ package io.iohk.scalanet.kconsole
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValue}
 import io.iohk.scalanet.peergroup.InetMultiAddress
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.aRandomAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import pureconfig.ConfigWriter
 import scodec.bits.BitVector
 

--- a/scalanet/examples/test/src/io/iohk/scalanet/kconsole/CommandParserSpec.scala
+++ b/scalanet/examples/test/src/io/iohk/scalanet/kconsole/CommandParserSpec.scala
@@ -11,7 +11,7 @@ import io.iohk.scalanet.kconsole.CommandParser.Command.{
   RemoveCommand
 }
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import org.scalatest.prop.TableDrivenPropertyChecks._

--- a/scalanet/kademlia/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/kademlia/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -1,10 +1,10 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.security.SecureRandom
 import java.util.concurrent.{Executors, TimeUnit}
 
-import io.iohk.scalanet.peergroup.kademlia.KNetwork.KNetworkScalanetImpl
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KNetwork.KNetworkScalanetImpl
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import io.iohk.scalanet.peergroup.{InetMultiAddress, InetPeerGroupUtils, UDPPeerGroup}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -190,8 +190,8 @@ object KademliaIntegrationSpec {
   val randomGen = new SecureRandom()
   val testBitLength = 16
 
-  import io.iohk.scalanet.codec.DefaultCodecs.KademliaMessages._
-  import io.iohk.scalanet.codec.DefaultCodecs.General._
+  import io.iohk.scalanet.codec.DefaultCodecs._
+  import io.iohk.scalanet.kademlia.codec.DefaultCodecs._
   import scodec.codecs.implicits._
 
   def startRouter(

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KBuckets.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KBuckets.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.time.Clock
 import java.util.Random

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KMessage.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KMessage.scala
@@ -1,8 +1,8 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.util.UUID
 
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import scodec.bits.BitVector
 
 sealed trait KMessage[A] {

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KNetwork.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KNetwork.scala
@@ -1,11 +1,11 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
-import io.iohk.scalanet.peergroup.Channel.MessageReceived
-import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
+import io.iohk.scalanet.peergroup.Channel.MessageReceived
 import monix.eval.Task
 import monix.reactive.Observable
 

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KRouter.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KRouter.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.security.SecureRandom
 import java.time.Clock
@@ -8,11 +8,11 @@ import cats.syntax.all._
 import cats.data.NonEmptySet
 import cats.effect.concurrent.Ref
 import com.typesafe.scalalogging.{CanLog, Logger}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
-import io.iohk.scalanet.peergroup.kademlia.KRouter.KRouterInternals._
-import io.iohk.scalanet.peergroup.kademlia.KRouter.{Config, NodeRecord}
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
+import io.iohk.scalanet.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.kademlia.KRouter.KRouterInternals._
+import io.iohk.scalanet.kademlia.KRouter.{Config, NodeRecord}
 import monix.eval.Task
 import monix.reactive.{Consumer, Observable, OverflowStrategy}
 import scodec.bits.BitVector

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/TimeSet.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/TimeSet.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.time.Clock
 import java.time.Clock.systemUTC

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/Xor.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/Xor.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import scodec.bits.BitVector
 

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/XorOrdering.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/XorOrdering.scala
@@ -1,7 +1,7 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import cats.Order
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import scodec.bits.BitVector
 
 class XorOrdering(val base: BitVector) extends Ordering[BitVector] {

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/codec/DefaultCodecs.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/codec/DefaultCodecs.scala
@@ -1,0 +1,25 @@
+package io.iohk.scalanet.kademlia.codec
+
+import io.iohk.scalanet.kademlia.KMessage
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
+import scodec.codecs.{Discriminated, Discriminator, uint4}
+
+/** Encodings for scodec. */
+object DefaultCodecs {
+  implicit def kMessageDiscriminator[A]: Discriminated[KMessage[A], Int] =
+    Discriminated[KMessage[A], Int](uint4)
+
+  implicit def findNodesDiscriminator[A]: Discriminator[KMessage[A], FindNodes[A], Int] =
+    Discriminator[KMessage[A], FindNodes[A], Int](0)
+
+  implicit def pingDiscriminator[A]: Discriminator[KMessage[A], Ping[A], Int] =
+    Discriminator[KMessage[A], Ping[A], Int](1)
+
+  implicit def nodesDiscriminator[A]: Discriminator[KMessage[A], Nodes[A], Int] =
+    Discriminator[KMessage[A], Nodes[A], Int](2)
+
+  implicit def pongDiscriminator[A]: Discriminator[KMessage[A], Pong[A], Int] =
+    Discriminator[KMessage[A], Pong[A], Int](3)
+
+}

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/Generators.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/Generators.scala
@@ -1,6 +1,6 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import scodec.bits.BitVector

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KBucketsSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KBucketsSpec.scala
@@ -1,10 +1,10 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.security.SecureRandom
 import java.time.Clock
 
-import io.iohk.scalanet.peergroup.kademlia.Generators._
-import io.iohk.scalanet.peergroup.kademlia.KBucketsSpec._
+import io.iohk.scalanet.kademlia.Generators._
+import io.iohk.scalanet.kademlia.KBucketsSpec._
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks._

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KNetworkRequestProcessing.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KNetworkRequestProcessing.scala
@@ -1,8 +1,8 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
+import io.iohk.scalanet.kademlia.KMessage.{KRequest, KResponse}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KNetworkSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KNetworkSpec.scala
@@ -1,15 +1,15 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.util.UUID
 
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse
+import io.iohk.scalanet.kademlia.KMessage.KResponse
 import java.util.concurrent.TimeoutException
 
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
 import io.iohk.scalanet.peergroup.{Channel, PeerGroup}
-import io.iohk.scalanet.peergroup.kademlia.KNetwork.KNetworkScalanetImpl
-import io.iohk.scalanet.peergroup.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.kademlia.KNetwork.KNetworkScalanetImpl
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
 import monix.eval.Task
 import monix.reactive.Observable
 import org.scalatest.FlatSpec
@@ -25,7 +25,7 @@ import KNetworkSpec._
 import io.iohk.scalanet.monix_subject.ConnectableSubject
 import io.iohk.scalanet.peergroup.Channel.MessageReceived
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest
+import io.iohk.scalanet.kademlia.KMessage.KRequest
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class KNetworkSpec extends FlatSpec {

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
@@ -1,19 +1,19 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.time.Clock
 import java.util.UUID
 
 import cats.effect.concurrent.Ref
-import io.iohk.scalanet.peergroup.kademlia.Generators.{aRandomBitVector, aRandomNodeRecord}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.{KRequest, KResponse}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
-import io.iohk.scalanet.peergroup.kademlia.KRouter.{Config, NodeRecord}
-import io.iohk.scalanet.peergroup.kademlia.KRouterSpec.KNetworkScalanetInternalTestImpl.{
+import io.iohk.scalanet.kademlia.Generators.{aRandomBitVector, aRandomNodeRecord}
+import io.iohk.scalanet.kademlia.KMessage.KRequest.{FindNodes, Ping}
+import io.iohk.scalanet.kademlia.KMessage.{KRequest, KResponse}
+import io.iohk.scalanet.kademlia.KMessage.KResponse.{Nodes, Pong}
+import io.iohk.scalanet.kademlia.KRouter.{Config, NodeRecord}
+import io.iohk.scalanet.kademlia.KRouterSpec.KNetworkScalanetInternalTestImpl.{
   KNetworkScalanetInternalTestImpl,
   NodeData
 }
-import io.iohk.scalanet.peergroup.kademlia.KRouterSpec._
+import io.iohk.scalanet.kademlia.KRouterSpec._
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/TimeSetSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/TimeSetSpec.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import java.time.Clock
 

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/XorOrderingSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/XorOrderingSpec.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/XorSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/XorSpec.scala
@@ -1,7 +1,7 @@
-package io.iohk.scalanet.peergroup.kademlia
+package io.iohk.scalanet.kademlia
 
-import io.iohk.scalanet.peergroup.kademlia.Generators._
-import io.iohk.scalanet.peergroup.kademlia.Xor._
+import io.iohk.scalanet.kademlia.Generators._
+import io.iohk.scalanet.kademlia.Xor._
 import org.scalacheck.Gen.posNum
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._

--- a/scalanet/src/io/iohk/scalanet/codec/DefaultCodecs.scala
+++ b/scalanet/src/io/iohk/scalanet/codec/DefaultCodecs.scala
@@ -3,12 +3,8 @@ package io.iohk.scalanet.codec
 import java.net.{InetAddress, InetSocketAddress}
 
 import io.iohk.scalanet.peergroup.InetMultiAddress
-import io.iohk.scalanet.peergroup.kademlia.KMessage
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KRequest.{FindNodes, Ping}
-import io.iohk.scalanet.peergroup.kademlia.KMessage.KResponse.{Nodes, Pong}
 import scodec.bits.{BitVector, ByteVector}
 import scodec.{Codec, DecodeResult}
-import scodec.codecs.{Discriminated, Discriminator}
 import scodec.codecs._
 import shapeless.Lazy
 import scodec.bits._
@@ -20,59 +16,39 @@ import scodec.bits._
   */
 object DefaultCodecs {
 
-  object General {
+  val ipv4Pad = hex"00 00 00 00 00 00 00 00 00 00 FF FF"
 
-    val ipv4Pad = hex"00 00 00 00 00 00 00 00 00 00 FF FF"
-
-    implicit val inetAddress = Codec[InetAddress](
-      (ia: InetAddress) => {
-        val bts = ByteVector(ia.getAddress)
-        if (bts.length == 4) {
-          bytes(16).encode(ipv4Pad ++ bts)
+  implicit val inetAddress = Codec[InetAddress](
+    (ia: InetAddress) => {
+      val bts = ByteVector(ia.getAddress)
+      if (bts.length == 4) {
+        bytes(16).encode(ipv4Pad ++ bts)
+      } else {
+        bytes(16).encode(bts)
+      }
+    },
+    (buf: BitVector) =>
+      bytes(16).decode(buf).map { b =>
+        val bts = if (b.value.take(12) == ipv4Pad) {
+          b.value.drop(12)
         } else {
-          bytes(16).encode(bts)
+          b.value
         }
-      },
-      (buf: BitVector) =>
-        bytes(16).decode(buf).map { b =>
-          val bts = if (b.value.take(12) == ipv4Pad) {
-            b.value.drop(12)
-          } else {
-            b.value
-          }
-          DecodeResult(InetAddress.getByAddress(bts.toArray), b.remainder)
-        }
-    )
+        DecodeResult(InetAddress.getByAddress(bts.toArray), b.remainder)
+      }
+  )
 
-    implicit val inetSocketAddress: Codec[InetSocketAddress] = {
-      ("host" | Codec[InetAddress]) ::
-        ("port" | uint16)
-    }.as[(InetAddress, Int)]
-      .xmap({ case (host, port) => new InetSocketAddress(host, port) }, isa => (isa.getAddress, isa.getPort))
+  implicit val inetSocketAddress: Codec[InetSocketAddress] = {
+    ("host" | Codec[InetAddress]) ::
+      ("port" | uint16)
+  }.as[(InetAddress, Int)]
+    .xmap({ case (host, port) => new InetSocketAddress(host, port) }, isa => (isa.getAddress, isa.getPort))
 
-    implicit val inetMultiAddressCodec: Codec[InetMultiAddress] = {
-      ("inetSocketAddress" | Codec[InetSocketAddress])
-    }.as[InetMultiAddress]
+  implicit val inetMultiAddressCodec: Codec[InetMultiAddress] = {
+    ("inetSocketAddress" | Codec[InetSocketAddress])
+  }.as[InetMultiAddress]
 
-    implicit def seqCoded[A](implicit listCodec: Lazy[Codec[List[A]]]): Codec[Seq[A]] = {
-      listCodec.value.xmap(l => l.toSeq, seq => seq.toList)
-    }
+  implicit def seqCoded[A](implicit listCodec: Lazy[Codec[List[A]]]): Codec[Seq[A]] = {
+    listCodec.value.xmap(l => l.toSeq, seq => seq.toList)
   }
-
-  object KademliaMessages {
-    implicit def kMessageDiscriminator[A]: Discriminated[KMessage[A], Int] = Discriminated[KMessage[A], Int](uint4)
-
-    implicit def findNodesDiscriminator[A]: Discriminator[KMessage[A], FindNodes[A], Int] =
-      Discriminator[KMessage[A], FindNodes[A], Int](0)
-
-    implicit def pingDiscriminator[A]: Discriminator[KMessage[A], Ping[A], Int] =
-      Discriminator[KMessage[A], Ping[A], Int](1)
-
-    implicit def nodesDiscriminator[A]: Discriminator[KMessage[A], Nodes[A], Int] =
-      Discriminator[KMessage[A], Nodes[A], Int](2)
-
-    implicit def pongDiscriminator[A]: Discriminator[KMessage[A], Pong[A], Int] =
-      Discriminator[KMessage[A], Pong[A], Int](3)
-  }
-
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -15,7 +15,6 @@ import io.iohk.scalanet.peergroup.ReqResponseProtocol.DynamicTLS
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKey
 import io.iohk.scalanet.peergroup.dynamictls.{DynamicTLSExtension, DynamicTLSPeerGroup, Secp256k1}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{Config, PeerInfo}
-import io.iohk.scalanet.peergroup.kademlia.KMessage
 import io.iohk.scalanet.testutils.GeneratorUtils
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -174,13 +173,9 @@ class DynamicTLSPeerGroupSpec extends AsyncFlatSpec with BeforeAndAfterAll {
   }
 
   it should "handle inform user about decoding error" in taskTestCase {
-    import io.iohk.scalanet.codec.DefaultCodecs.KademliaMessages._
-    import io.iohk.scalanet.codec.DefaultCodecs.General._
-    import scodec.codecs.implicits._
-
-    implicit val s = new FramingCodec[KMessage[String]](Codec[KMessage[String]])
+    implicit val s = new FramingCodec[TestMessage[String]](Codec[TestMessage[String]])
     val client = new DynamicTLSPeerGroup[String](getCorrectConfig())
-    val server = new DynamicTLSPeerGroup[KMessage[String]](getCorrectConfig())
+    val server = new DynamicTLSPeerGroup[TestMessage[String]](getCorrectConfig())
 
     for {
       _ <- client.initialize()

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
@@ -12,7 +12,6 @@ import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import org.scalatest.concurrent.ScalaFutures._
 import io.iohk.scalanet.peergroup.PeerGroup.{ChannelAlreadyClosedException, MessageMTUException}
 import io.iohk.scalanet.peergroup.StandardTestPack._
-import io.iohk.scalanet.peergroup.kademlia.KMessage
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.RecoverMethods._
@@ -184,12 +183,10 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
 
   it should "inform user if there was decoding error on the channel" in {
     import UDPPeerGroupSpecUtils._
-    import io.iohk.scalanet.codec.DefaultCodecs.KademliaMessages._
-    import io.iohk.scalanet.codec.DefaultCodecs.General._
     import scodec.codecs.implicits._
     (for {
       pg1 <- initUdpPeerGroup[String]()
-      pg2 <- initUdpPeerGroup[KMessage[String]]()
+      pg2 <- initUdpPeerGroup[TestMessage[String]]()
       ch1 <- pg1.client(pg2.processAddress)
       result <- Task.parZip2(
         ch1.sendMessage("Helllo wrong server"),

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/package.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/package.scala
@@ -1,0 +1,22 @@
+package io.iohk.scalanet
+
+import scodec.codecs.{Discriminated, Discriminator, uint4}
+
+package object peergroup {
+
+  // A message we can use in tests with a format that's definitely not ambiguous with the encoding of a String.
+  sealed trait TestMessage[A]
+  object TestMessage {
+    case class Foo[A](value: A) extends TestMessage[A]
+    case class Bar[A](value: A) extends TestMessage[A]
+
+    implicit def testMessageDiscriminator[A]: Discriminated[TestMessage[A], Int] =
+      Discriminated[TestMessage[A], Int](uint4)
+
+    implicit def fooDiscriminator[A]: Discriminator[TestMessage[A], Foo[A], Int] =
+      Discriminator[TestMessage[A], Foo[A], Int](0)
+
+    implicit def barDiscriminator[A]: Discriminator[TestMessage[A], Bar[A], Int] =
+      Discriminator[TestMessage[A], Bar[A], Int](1)
+  }
+}


### PR DESCRIPTION
Moves the current Kademlia packages from the `scalanet` module to a separate one so that we can change it to implement Ethereum Discovery v4 without introducing Ethereum specific dependencies to the core. Changed the package path from `io.iohk.scalanet.peergroup.kademlia` to just `io.iohk.scalanet.kademlia`. 

I left a comment in the README about publishing multiple modules with mill. I'm not sure how it works at the moment or how it's going to realise which modules need to be published (scalanet and kademlia).