### PR TITLE
ETCM-162: Rename UDPPeerGroup to DynamicUDPPeerGroup

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -58,10 +58,7 @@ trait CoreDependency extends ScalaModule {
     super.moduleDeps ++ Seq(scalanet)
 }
 
-trait SubModule extends ScalanetModule with CoreDependency {
-  override def moduleDeps: Seq[JavaModule] =
-    super.moduleDeps ++ Seq(scalanet)
-}
+trait SubModule extends ScalanetModule with CoreDependency
 
 // ScoverageModule creates bug when using custom repositories:
 // https://github.com/lihaoyi/mill/issues/620

--- a/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
+++ b/scalanet/examples/src/io/iohk/scalanet/kconsole/AppContext.scala
@@ -1,6 +1,7 @@
 package io.iohk.scalanet.kconsole
 
-import io.iohk.scalanet.peergroup.{InetMultiAddress, PeerGroup, UDPPeerGroup}
+import io.iohk.scalanet.peergroup.{InetMultiAddress, PeerGroup}
+import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
 import io.iohk.scalanet.kademlia.KNetwork.KNetworkScalanetImpl
 import io.iohk.scalanet.kademlia.{KMessage, KRouter}
 import monix.execution.Scheduler
@@ -14,11 +15,11 @@ class AppContext(nodeConfig: KRouter.Config[InetMultiAddress])(implicit schedule
 
     try {
       val routingConfig =
-        UDPPeerGroup.Config(
+        DynamicUDPPeerGroup.Config(
           nodeConfig.nodeRecord.routingAddress.inetSocketAddress
         )
       val routingPeerGroup = PeerGroup.createOrThrow(
-        new UDPPeerGroup[KMessage[InetMultiAddress]](routingConfig),
+        new DynamicUDPPeerGroup[KMessage[InetMultiAddress]](routingConfig),
         routingConfig
       )
       val kNetwork =

--- a/scalanet/src/io/iohk/scalanet/peergroup/ControlEvent.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ControlEvent.scala
@@ -1,10 +1,14 @@
 package io.iohk.scalanet.peergroup
 
+import scala.util.control.NoStackTrace
+
 sealed trait ControlEvent
 
 object ControlEvent {
 
   case object Initialized
 
-  case class InitializationError(message: String, cause: Throwable) extends RuntimeException(message, cause)
+  case class InitializationError(message: String, cause: Throwable)
+      extends RuntimeException(message, cause)
+      with NoStackTrace
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetPeerGroupUtils.scala
@@ -9,6 +9,7 @@ object InetPeerGroupUtils {
 
   type ChannelId = (InetSocketAddress, InetSocketAddress)
 
+  // TODO: This has nothing to do with InetPeerGroup, move it somewhere else.
   def toTask(f: => util.concurrent.Future[_]): Task[Unit] = {
     Task.async[Unit] { cb =>
       try {
@@ -26,6 +27,7 @@ object InetPeerGroupUtils {
     (remoteAddress, localAddress)
   }
 
+  // TODO: Can we move this to tests?
   def aRandomAddress(): InetSocketAddress = {
     val s = new ServerSocket(0)
     try {

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -1,14 +1,13 @@
 package io.iohk.scalanet.peergroup
 
 import io.iohk.scalanet.peergroup.Channel.ChannelEvent
-import scodec.Codec
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.observables.ConnectableObservable
-
+import scodec.Codec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -138,13 +138,13 @@ object ReqResponseProtocol {
         address: InetSocketAddress
     )(implicit s: Scheduler, c: Codec[M]): Task[ReqResponseProtocol[AddressingType, M]]
   }
-  case object Udp extends TransportProtocol {
+  case object DynamicUDP extends TransportProtocol {
     override type AddressingType = InetMultiAddress
 
     override def getProtocol[M](
         address: InetSocketAddress
     )(implicit s: Scheduler, c: Codec[M]): Task[ReqResponseProtocol[InetMultiAddress, M]] = {
-      getUdpReqResponseProtocolClient(address)
+      getDynamicUdpReqResponseProtocolClient(address)
     }
   }
 
@@ -173,7 +173,7 @@ object ReqResponseProtocol {
     } yield prot
   }
 
-  def getUdpReqResponseProtocolClient[M](
+  def getDynamicUdpReqResponseProtocolClient[M](
       address: InetSocketAddress
   )(implicit s: Scheduler, c: Codec[M]): Task[ReqResponseProtocol[InetMultiAddress, M]] = {
     val pg1 = new DynamicUDPPeerGroup[MessageEnvelope[M]](DynamicUDPPeerGroup.Config(address))

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -8,10 +8,11 @@ import cats.effect.concurrent.Ref
 import io.iohk.scalanet.codec.FramingCodec
 import io.iohk.scalanet.crypto.CryptoUtils
 import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, MessageReceived}
-import io.iohk.scalanet.peergroup.dynamictls.{DynamicTLSPeerGroup, Secp256k1}
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.ChannelId
 import io.iohk.scalanet.peergroup.ReqResponseProtocol._
+import io.iohk.scalanet.peergroup.dynamictls.{DynamicTLSPeerGroup, Secp256k1}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.PeerInfo
+import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.observables.ConnectableObservable
@@ -175,7 +176,7 @@ object ReqResponseProtocol {
   def getUdpReqResponseProtocolClient[M](
       address: InetSocketAddress
   )(implicit s: Scheduler, c: Codec[M]): Task[ReqResponseProtocol[InetMultiAddress, M]] = {
-    val pg1 = new UDPPeerGroup[MessageEnvelope[M]](UDPPeerGroup.Config(address))
+    val pg1 = new DynamicUDPPeerGroup[MessageEnvelope[M]](DynamicUDPPeerGroup.Config(address))
     buildProtocol(pg1)
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
 
 /**
   * PeerGroup implementation on top of UDP that always opens a new channel
-  * from a random port when sending a message to a remote address.
+  * from a random port when it creates a new client to a given remote address.
   *
   * @param config bind address etc. See the companion object.
   * @param codec a scodec codec for reading writing messages to NIO ByteBuffer.

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup
+package io.iohk.scalanet.peergroup.udp
 
 import java.io.IOException
 import java.net.{InetSocketAddress, PortUnreachableException}
@@ -7,13 +7,12 @@ import java.util.concurrent.ConcurrentHashMap
 import cats.syntax.functor._
 import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.monix_subject.ConnectableSubject
+import io.iohk.scalanet.peergroup.{Channel, InetMultiAddress}
 import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, DecodingError, MessageReceived, UnexpectedError}
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
 import io.iohk.scalanet.peergroup.PeerGroup._
-import io.iohk.scalanet.peergroup.UDPPeerGroup.UDPPeerGroupInternals.{ChannelType, UdpChannelId}
-import io.iohk.scalanet.peergroup.UDPPeerGroup.{UDPPeerGroupInternals, _}
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
 import io.netty.channel
@@ -30,24 +29,27 @@ import scodec.{Attempt, Codec}
 import scala.util.control.NonFatal
 
 /**
-  * PeerGroup implementation on top of UDP.
+  * PeerGroup implementation on top of UDP that always opens a new channel
+  * from a random port when sending a message to a remote address.
   *
   * @param config bind address etc. See the companion object.
   * @param codec a scodec codec for reading writing messages to NIO ByteBuffer.
   * @tparam M the message type.
   */
-class UDPPeerGroup[M](val config: Config)(
+class DynamicUDPPeerGroup[M](val config: DynamicUDPPeerGroup.Config)(
     implicit codec: Codec[M],
     scheduler: Scheduler
 ) extends TerminalPeerGroup[InetMultiAddress, M]()
     with StrictLogging {
+
+  import DynamicUDPPeerGroup.Internals.{UDPChannelId, ChannelType, ClientChannel, ServerChannel}
 
   val serverSubject = ConnectableSubject[ServerEvent[InetMultiAddress, M]]()
 
   private val workerGroup = new NioEventLoopGroup()
 
   // all channels in the map are open and active, as upon closing channels are removed from the map
-  private[peergroup] val activeChannels = new ConcurrentHashMap[UdpChannelId, ChannelImpl]()
+  private[peergroup] val activeChannels = new ConcurrentHashMap[UDPChannelId, ChannelImpl]()
 
   /**
     * Listener will run when ChannelImpl closed promise will be completed. Channel close promise will run on underlying netty channel
@@ -78,7 +80,7 @@ class UDPPeerGroup[M](val config: Config)(
     }
   }
 
-  private def handleError(channelId: UdpChannelId, error: Throwable): Unit = {
+  private def handleError(channelId: UDPChannelId, error: Throwable): Unit = {
     // Inform about error only if channel is available and open
     Option(activeChannels.get(channelId)).foreach { ch =>
       logger.debug("Unexpected error {} on channel {}", error: Any, channelId: Any)
@@ -103,7 +105,7 @@ class UDPPeerGroup[M](val config: Config)(
               val datagram = msg.asInstanceOf[DatagramPacket]
               val remoteAddress = datagram.sender()
               val localAddress = datagram.recipient()
-              val udpChannelId = UdpChannelId(ctx.channel().id(), remoteAddress, localAddress)
+              val udpChannelId = UDPChannelId(ctx.channel().id(), remoteAddress, localAddress)
               try {
                 logger.info(s"Client channel read message with remote $remoteAddress and local $localAddress")
                 Option(activeChannels.get(udpChannelId)).foreach(handleIncomingMessage(_, datagram))
@@ -118,7 +120,7 @@ class UDPPeerGroup[M](val config: Config)(
               val channelId = ctx.channel().id()
               val localAddress = ctx.channel().localAddress().asInstanceOf[InetSocketAddress]
               val remoteAddress = ctx.channel.remoteAddress().asInstanceOf[InetSocketAddress]
-              val udpChannelId = UdpChannelId(channelId, remoteAddress, localAddress)
+              val udpChannelId = UDPChannelId(channelId, remoteAddress, localAddress)
               cause match {
                 case _: PortUnreachableException =>
                   // we do not want ugly exception, but we do not close the channel, it is entirely up to user to close not
@@ -154,7 +156,7 @@ class UDPPeerGroup[M](val config: Config)(
                 localAddress,
                 remoteAddress,
                 ConnectableSubject[ChannelEvent[M]](),
-                UDPPeerGroupInternals.ServerChannel
+                ServerChannel
               )
               try {
                 Option(activeChannels.putIfAbsent(potentialNewChannel.channelId, potentialNewChannel)) match {
@@ -176,7 +178,7 @@ class UDPPeerGroup[M](val config: Config)(
             }
 
             override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-              // We cannot create UdpChannelId as on udp netty server channel there is no remote peer address.
+              // We cannot create UDPChannelId as on udp netty server channel there is no remote peer address.
               logger.error(s"Unexpected server error ${cause.getMessage}")
             }
           })
@@ -188,12 +190,12 @@ class UDPPeerGroup[M](val config: Config)(
       localAddress: InetSocketAddress,
       remoteAddress: InetSocketAddress,
       val messageSubject: ConnectableSubject[ChannelEvent[M]],
-      channelType: UDPPeerGroupInternals.ChannelType
+      channelType: ChannelType
   ) extends Channel[InetMultiAddress, M] {
 
     val closePromise: Promise[ChannelImpl] = nettyChannel.eventLoop().newPromise[ChannelImpl]()
 
-    val channelId = UdpChannelId(nettyChannel.id(), remoteAddress, localAddress)
+    val channelId = UDPChannelId(nettyChannel.id(), remoteAddress, localAddress)
 
     logger.debug(
       s"Setting up new channel from local address $localAddress " +
@@ -223,11 +225,11 @@ class UDPPeerGroup[M](val config: Config)(
 
     private def closeNettyChannel(channelType: ChannelType): Task[Unit] = {
       channelType match {
-        case UDPPeerGroupInternals.ServerChannel =>
+        case ServerChannel =>
           // on netty side there is only one channel for accepting incoming connection so if we close it, we will effectively
           // close server
           Task.now(())
-        case UDPPeerGroupInternals.ClientChannel =>
+        case ClientChannel =>
           // each client connection creates new channel on netty side
           toTask(nettyChannel.close())
       }
@@ -288,7 +290,7 @@ class UDPPeerGroup[M](val config: Config)(
           localAddress,
           to.inetSocketAddress,
           ConnectableSubject[ChannelEvent[M]](),
-          UDPPeerGroupInternals.ClientChannel
+          ClientChannel
         )
         // By using netty channel id as part of our channel id, we make sure that each client channel is unique
         // therefore there won't be such channels in active channels map already.
@@ -314,7 +316,7 @@ class UDPPeerGroup[M](val config: Config)(
   }
 }
 
-object UDPPeerGroup {
+object DynamicUDPPeerGroup {
 
   val mtu: Int = 16384
 
@@ -327,12 +329,12 @@ object UDPPeerGroup {
     def apply(bindAddress: InetSocketAddress): Config = Config(bindAddress, InetMultiAddress(bindAddress))
   }
 
-  private[scalanet] object UDPPeerGroupInternals {
+  private[scalanet] object Internals {
     sealed abstract class ChannelType
     case object ServerChannel extends ChannelType
     case object ClientChannel extends ChannelType
 
-    final case class UdpChannelId(
+    final case class UDPChannelId(
         nettyChannelId: io.netty.channel.ChannelId,
         remoteAddress: InetSocketAddress,
         localAddress: InetSocketAddress

--- a/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
@@ -5,7 +5,8 @@ import java.nio.ByteBuffer
 import java.security.KeyStore
 import java.security.cert.Certificate
 
-import io.iohk.scalanet.peergroup._
+import io.iohk.scalanet.peergroup.InetPeerGroupUtils
+import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
 import monix.execution.Scheduler
 import scodec.Codec
 
@@ -84,14 +85,14 @@ object NetUtils {
   def randomUDPPeerGroup[M](
       implicit scheduler: Scheduler,
       codec: Codec[M]
-  ): UDPPeerGroup[M] = {
-    val pg = new UDPPeerGroup(UDPPeerGroup.Config(aRandomAddress()))
+  ): DynamicUDPPeerGroup[M] = {
+    val pg = new DynamicUDPPeerGroup(DynamicUDPPeerGroup.Config(aRandomAddress()))
     Await.result(pg.initialize().runToFuture, 10 seconds)
     pg
   }
 
   def withTwoRandomUDPPeerGroups[M](
-      testCode: (UDPPeerGroup[M], UDPPeerGroup[M]) => Any
+      testCode: (DynamicUDPPeerGroup[M], DynamicUDPPeerGroup[M]) => Any
   )(implicit scheduler: Scheduler, codec: Codec[M]): Unit = {
     val pg1 = randomUDPPeerGroup
     val pg2 = randomUDPPeerGroup
@@ -104,7 +105,7 @@ object NetUtils {
   }
 
   def withARandomUDPPeerGroup[M](
-      testCode: UDPPeerGroup[M] => Any
+      testCode: DynamicUDPPeerGroup[M] => Any
   )(implicit scheduler: Scheduler, codec: Codec[M]): Unit = {
     val pg = randomUDPPeerGroup
     try {

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
@@ -31,7 +31,7 @@ class TransportPeerGroupAsyncSpec extends AsyncFlatSpec with BeforeAndAfterAll {
 
   private val rpcs = Table(
     ("Label", "Transport type"),
-    ("UDP", Udp),
+    ("UDP", DynamicUDP),
     ("DTLS", DynamicTLS)
   )
   forAll(rpcs) { (label, transportType) =>

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/UDPPeerGroupSpec.scala
@@ -12,6 +12,7 @@ import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import org.scalatest.concurrent.ScalaFutures._
 import io.iohk.scalanet.peergroup.PeerGroup.{ChannelAlreadyClosedException, MessageMTUException}
 import io.iohk.scalanet.peergroup.StandardTestPack._
+import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.RecoverMethods._
@@ -251,8 +252,8 @@ object UDPPeerGroupSpecUtils {
 
   def initUdpPeerGroup[M](
       address: InetSocketAddress = aRandomAddress()
-  )(implicit s: Scheduler, c: Codec[M]): Task[UDPPeerGroup[M]] = {
-    val pg = new UDPPeerGroup[M](UDPPeerGroup.Config(address))
+  )(implicit s: Scheduler, c: Codec[M]): Task[DynamicUDPPeerGroup[M]] = {
+    val pg = new DynamicUDPPeerGroup[M](DynamicUDPPeerGroup.Config(address))
     pg.initialize().map(_ => pg)
   }
 


### PR DESCRIPTION
Renames the existing `UDPPeerGroup` to `DynamicUDPPeerGroup` to reflect the fact that it always creates a new client channel from a random port, in contrast to the `StaticUDPPeerGroup` which will reuse the same port (to be developed).