### PR TITLE
ETCM-162: StaticUDPPeerGroup

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -24,6 +24,7 @@ trait ScalanetModule extends ScalaModule {
     "-Xlint:unsound-match",
     "-Ywarn-inaccessible",
     "-Ywarn-unused-import",
+    "-Ywarn-value-discard",
     "-Ypartial-unification",
     "-J-Xmx1.5G",
     "-J-Xms1.5G",

--- a/scalanet/kademlia/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/kademlia/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -27,6 +27,7 @@ class KademliaIntegrationSpec extends AsyncFlatSpec with BeforeAndAfterAll with 
   override def afterAll(): Unit = {
     threadPool.shutdown()
     threadPool.awaitTermination(60, TimeUnit.SECONDS)
+    ()
   }
 
   behavior of "Kademlia"

--- a/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
+++ b/scalanet/kademlia/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
@@ -197,7 +197,7 @@ class KRouterSpec extends FreeSpec with Eventually {
             bin"1110",
             bin"1111"
           )
-        })
+        }.void)
       }
 
       "when a bucket is full and the head unresponsive, that head entry should be evicted and sender inserted at the tail " in {
@@ -215,7 +215,7 @@ class KRouterSpec extends FreeSpec with Eventually {
           krouter.kBuckets.runSyncUnsafe().buckets(1) shouldBe TimeSet(bin"0010", bin"0011")
           krouter.kBuckets.runSyncUnsafe().buckets(2) shouldBe TimeSet(bin"0101", bin"0110", bin"0111")
           krouter.kBuckets.runSyncUnsafe().buckets(3) shouldBe TimeSet(bin"1101", bin"1110", bin"1111")
-        })
+        }.void)
       }
 
       "when the bucket is full and the head responsive, that head entry should be moved to the tail and the sender discarded" in {
@@ -229,7 +229,7 @@ class KRouterSpec extends FreeSpec with Eventually {
           krouter.kBuckets.runSyncUnsafe().buckets(1) shouldBe TimeSet(bin"0010", bin"0011")
           krouter.kBuckets.runSyncUnsafe().buckets(2) shouldBe TimeSet(bin"0101", bin"0110", bin"0100")
           krouter.kBuckets.runSyncUnsafe().buckets(3) shouldBe TimeSet(bin"1010", bin"1000", bin"1001")
-        })
+        }.void)
       }
     }
 
@@ -532,6 +532,8 @@ object KRouterSpec {
       Observable.fromIterable(ids.map(id => (Ping(uuid, aRandomNodeRecord(bitLength).copy(id = id)), handler)))
 
     when(knetwork.kRequests).thenReturn(kRequests)
+
+    ()
   }
 
   private def mockEnrollment(
@@ -546,6 +548,8 @@ object KRouterSpec {
         val to = invocation.getArgument(0).asInstanceOf[NodeRecord[String]]
         Task.now(Nodes(uuid, to, otherNodes))
       })
+
+    ()
   }
 
   private def anyOf[T](s: Set[T]): T = {

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetPeerGroupUtils.scala
@@ -16,6 +16,7 @@ object InetPeerGroupUtils {
         f.addListener(
           (future: util.concurrent.Future[_]) => if (future.isSuccess) cb.onSuccess(()) else cb.onError(future.cause())
         )
+        ()
       } catch {
         case t: Throwable =>
           cb.onError(t)

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -46,7 +46,7 @@ import scala.util.control.NonFatal
 class DynamicTLSPeerGroup[M] private (val config: Config)(
     implicit codec: StreamCodec[M],
     scheduler: Scheduler
-) extends TerminalPeerGroup[PeerInfo, M]()
+) extends TerminalPeerGroup[PeerInfo, M]
     with StrictLogging {
 
   private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForServer, config)

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -1,0 +1,366 @@
+package io.iohk.scalanet.peergroup.udp
+
+import cats.effect.concurrent.Ref
+import cats.effect.Resource
+import cats.implicits._
+import com.typesafe.scalalogging.StrictLogging
+import io.iohk.scalanet.monix_subject.ConnectableSubject
+import io.iohk.scalanet.peergroup.{Channel, Release}
+import io.iohk.scalanet.peergroup.{InetMultiAddress}
+import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, MessageReceived, DecodingError}
+import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
+import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
+import io.iohk.scalanet.peergroup.PeerGroup.{ServerEvent, TerminalPeerGroup, MessageMTUException}
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.Unpooled
+import io.netty.channel.{
+  RecvByteBufAllocator,
+  ChannelOption,
+  ChannelInitializer,
+  ChannelHandlerContext,
+  ChannelInboundHandlerAdapter
+}
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.DatagramPacket
+import io.netty.channel.socket.nio.NioDatagramChannel
+import java.io.IOException
+import java.net.{InetSocketAddress, PortUnreachableException}
+import monix.eval.Task
+import monix.execution.Scheduler
+import scala.util.control.NonFatal
+import scodec.{Codec, Attempt}
+import scodec.bits.BitVector
+import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
+import io.iohk.scalanet.peergroup.Channel.UnexpectedError
+import monix.execution.schedulers.CanBlock
+
+/**
+  * PeerGroup implementation on top of UDP that uses the same local port
+  * when creating channels to remote addresses as the one it listens on
+  * for incoming messages. This makes it compatible with certain UDP
+  * based node discovery protocols. It also means that incoming messages
+  * cannot be tied to a specific channel, so if multiple channels are
+  * open to the same remote address, they will all see the same messages.
+  *
+  * @param config bind address etc. See the companion object.
+  * @param codec a scodec codec for reading writing messages to NIO ByteBuffer.
+  * @tparam M the message type.
+  */
+class StaticUDPPeerGroup[M] private (
+    config: StaticUDPPeerGroup.Config,
+    workerGroup: NioEventLoopGroup,
+    isShutdownRef: Ref[Task, Boolean],
+    serverSubject: ConnectableSubject[ServerEvent[InetMultiAddress, M]],
+    serverChannelsRef: Ref[Task, Map[InetSocketAddress, StaticUDPPeerGroup.ChannelRelease[M]]],
+    clientChannelsRef: Ref[Task, Map[InetSocketAddress, Set[StaticUDPPeerGroup.ChannelRelease[M]]]]
+)(implicit scheduler: Scheduler, codec: Codec[M])
+    extends TerminalPeerGroup[InetMultiAddress, M]
+    with StrictLogging {
+
+  import StaticUDPPeerGroup.{ChannelImpl, ChannelRelease, TaskExecutionOps}
+
+  override val processAddress = config.processAddress
+  override val server = serverSubject
+
+  private def raiseIfShutdown =
+    isShutdownRef.get
+      .ifM(Task.raiseError(new IllegalStateException("The peer group has already been shut down.")), Task.unit)
+
+  /** Create a new channel from the local server port to the remote address. */
+  override def client(to: InetMultiAddress): Resource[Task, Channel[InetMultiAddress, M]] = {
+    for {
+      _ <- Resource.liftF(raiseIfShutdown)
+      channel <- Resource {
+        ChannelImpl[M](
+          nettyChannel = serverBinding.channel,
+          localAddress = config.bindAddress,
+          remoteAddress = to.inetSocketAddress
+        ).allocated.flatMap {
+          case (channel, release) =>
+            // Register the channel as belonging to the remote address so that
+            // we can replicate incoming messages to it later.
+            val add = for {
+              _ <- addClientChannel(channel -> release)
+              _ <- Task(logger.debug(s"Added UDP client channel to $to"))
+            } yield ()
+
+            val remove = for {
+              _ <- removeClientChannel(channel -> release)
+              _ <- release
+              _ <- Task(logger.debug(s"Removed UDP client channel to $to"))
+            } yield ()
+
+            add.as(channel -> remove)
+        }
+      }
+    } yield channel
+  }
+
+  private def addClientChannel(channel: ChannelRelease[M]) =
+    clientChannelsRef.update { clientChannels =>
+      val remoteAddress = channel._1.to.inetSocketAddress
+      val current = clientChannels.getOrElse(remoteAddress, Set.empty)
+      clientChannels.updated(remoteAddress, current + channel)
+    }
+
+  private def removeClientChannel(channel: ChannelRelease[M]) =
+    clientChannelsRef.update { clientChannels =>
+      val remoteAddress = channel._1.to.inetSocketAddress
+      val current = clientChannels.getOrElse(remoteAddress, Set.empty)
+      val removed = current - channel
+      if (removed.isEmpty) clientChannels - remoteAddress else clientChannels.updated(remoteAddress, removed)
+    }
+
+  private def getOrCreateServerChannel(remoteAddress: InetSocketAddress): Task[ChannelImpl[M]] = {
+    serverChannelsRef.get.map(_.get(remoteAddress)).flatMap {
+      case Some((channel, _)) =>
+        Task.pure(channel)
+
+      case None =>
+        // All incoming messages are handled on the same event loop, by the same channel,
+        // so we don't have to synchronize anything, it will only try to create one channel at a time.
+        ChannelImpl[M](
+          nettyChannel = serverBinding.channel,
+          localAddress = config.bindAddress,
+          remoteAddress = remoteAddress
+        ).allocated.flatMap {
+          case (channel, release) =>
+            val remove = for {
+              _ <- serverChannelsRef.update(_ - remoteAddress)
+              _ <- release
+              _ <- Task(logger.debug(s"Removed UDP server channel from $remoteAddress"))
+            } yield ()
+
+            val add = for {
+              _ <- serverChannelsRef.update(_.updated(remoteAddress, channel -> release))
+              _ <- Task(serverSubject.onNext(ChannelCreated(channel, remove)))
+              _ <- Task(logger.debug(s"Added UDP server channel from $remoteAddress"))
+            } yield channel
+
+            add.as(channel)
+        }
+    }
+  }
+
+  private def getClientChannels(remoteAddress: InetSocketAddress): Task[Iterable[ChannelImpl[M]]] =
+    clientChannelsRef.get.map {
+      _.getOrElse(remoteAddress, Set.empty).toIterable.map(_._1)
+    }
+
+  private def replicateToChannels(remoteAddress: InetSocketAddress)(f: ChannelImpl[M] => Task[Unit]): Task[Unit] =
+    isShutdownRef.get.ifM(
+      Task.unit,
+      for {
+        serverChannel <- getOrCreateServerChannel(remoteAddress)
+        clientChannels <- getClientChannels(remoteAddress)
+        channels = Iterable(serverChannel) ++ clientChannels
+        _ <- Task.parTraverseUnordered(channels)(f)
+      } yield ()
+    )
+
+  /** Replicate the incoming message to the server channel and all client channels connected to the remote address. */
+  private def handleMessage(remoteAddress: InetSocketAddress, maybeMessage: Attempt[M]): Task[Unit] =
+    replicateToChannels(remoteAddress)(_.handleMessage(maybeMessage))
+
+  private def handleError(remoteAddress: InetSocketAddress, error: Throwable): Task[Unit] =
+    replicateToChannels(remoteAddress)(_.handleError(error))
+
+  private def tryDecodeDatagram(datagram: DatagramPacket): Attempt[M] =
+    codec.decodeValue(BitVector(datagram.content.nioBuffer))
+
+  private lazy val serverBinding =
+    new Bootstrap()
+      .group(workerGroup)
+      .channel(classOf[NioDatagramChannel])
+      .option[RecvByteBufAllocator](
+        ChannelOption.RCVBUF_ALLOCATOR,
+        new io.netty.channel.DefaultMaxBytesRecvByteBufAllocator()
+      )
+      .handler(new ChannelInitializer[NioDatagramChannel]() {
+        override def initChannel(nettyChannel: NioDatagramChannel): Unit = {
+          nettyChannel
+            .pipeline()
+            .addLast(new ChannelInboundHandlerAdapter() {
+              override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
+                val datagram = msg.asInstanceOf[DatagramPacket]
+                val remoteAddress = datagram.sender
+                try {
+                  logger.debug(s"Server channel read message from $remoteAddress")
+                  handleMessage(remoteAddress, tryDecodeDatagram(datagram)).executeOn(ctx)
+                } catch {
+                  case NonFatal(ex) =>
+                    handleError(remoteAddress, ex).executeOn(ctx)
+                } finally {
+                  datagram.content().release()
+                  ()
+                }
+              }
+
+              override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+                val channelId = ctx.channel().id()
+                val remoteAddress = ctx.channel.remoteAddress().asInstanceOf[InetSocketAddress]
+                cause match {
+                  case _: PortUnreachableException =>
+                    // We do not want ugly exception, but we do not close the channel,
+                    // it is entirely up to user to close not responding channels.
+                    logger.info(s"Peer with ip $remoteAddress not available")
+                  case _ =>
+                    super.exceptionCaught(ctx, cause)
+                }
+                cause match {
+                  case NonFatal(ex) =>
+                    handleError(remoteAddress, ex).executeOn(ctx)
+                }
+              }
+            })
+
+          ()
+        }
+      })
+      .bind(config.bindAddress)
+
+  // Wait until the server is bound.
+  private def initialize(): Task[Unit] =
+    raiseIfShutdown >>
+      toTask(serverBinding).onErrorRecoverWith {
+        case NonFatal(ex) =>
+          Task.raiseError(InitializationError(ex.getMessage, ex.getCause))
+      } >> Task(logger.info(s"Server bound to address ${config.bindAddress}"))
+
+  private def shutdown(): Task[Unit] = {
+    for {
+      _ <- Task(logger.info(s"Shutting down UDP peer group for peer ${config.processAddress}"))
+      // Mark the group as shutting down to stop accepting incoming connections.
+      _ <- isShutdownRef.set(true)
+      _ <- Task(serverSubject.onComplete())
+      // Release client channels.
+      _ <- clientChannelsRef.get.map(_.values.flatten.toList.map(_._2.attempt).sequence)
+      // Release server channels.
+      _ <- serverChannelsRef.get.map(_.values.toList.map(_._2.attempt).sequence)
+      // Stop the in and outgoing traffic.
+      _ <- toTask(serverBinding.channel.close())
+    } yield ()
+  }
+
+}
+
+object StaticUDPPeerGroup extends StrictLogging {
+  case class Config(
+      bindAddress: InetSocketAddress,
+      processAddress: InetMultiAddress
+  )
+  object Config {
+    def apply(bindAddress: InetSocketAddress): Config = Config(bindAddress, InetMultiAddress(bindAddress))
+  }
+
+  private type ChannelRelease[M] = (ChannelImpl[M], Release)
+
+  def apply[M: Codec](config: Config)(implicit scheduler: Scheduler): Resource[Task, StaticUDPPeerGroup[M]] =
+    makeEventLoop.flatMap { workerGroup =>
+      Resource.make {
+        for {
+          isShutdownRef <- Ref[Task].of(false)
+          clientChannelsRef <- Ref[Task].of(Map.empty[InetSocketAddress, Set[ChannelRelease[M]]])
+          serverChannelsRef <- Ref[Task].of(Map.empty[InetSocketAddress, ChannelRelease[M]])
+          serverSubject = ConnectableSubject[ServerEvent[InetMultiAddress, M]]()
+          peerGroup = new StaticUDPPeerGroup[M](
+            config,
+            workerGroup,
+            isShutdownRef,
+            serverSubject,
+            serverChannelsRef,
+            clientChannelsRef
+          )
+          _ <- peerGroup.initialize()
+        } yield peerGroup
+      }(_.shutdown())
+    }
+
+  // Separate resource so if the server initialization fails, this still gets shut down.
+  private val makeEventLoop =
+    Resource.make {
+      Task(new NioEventLoopGroup())
+    } { group =>
+      toTask(group.shutdownGracefully())
+    }
+
+  private class ChannelImpl[M](
+      nettyChannel: io.netty.channel.Channel,
+      localAddress: InetSocketAddress,
+      remoteAddress: InetSocketAddress,
+      messageSubject: ConnectableSubject[ChannelEvent[M]],
+      isClosedRef: Ref[Task, Boolean]
+  )(implicit codec: Codec[M])
+      extends Channel[InetMultiAddress, M]
+      with StrictLogging {
+    override val to = InetMultiAddress(remoteAddress)
+    override val in = messageSubject
+
+    override def sendMessage(message: M) =
+      for {
+        _ <- isClosedRef.get.ifM(Task.raiseError(new IllegalStateException("Channel is already closed.")), Task.unit)
+        _ <- Task(logger.debug(s"Sending message ${message} to peer ${remoteAddress}"))
+        encodedMessage <- Task.fromTry(codec.encode(message).toTry)
+        asBuffer = encodedMessage.toByteBuffer
+        packet = new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), remoteAddress, localAddress)
+        _ <- toTask(nettyChannel.writeAndFlush(packet)).onErrorRecoverWith {
+          case _: IOException =>
+            Task.raiseError(new MessageMTUException[InetMultiAddress](to, asBuffer.capacity))
+        }
+      } yield ()
+
+    def handleMessage(maybeMessage: Attempt[M]): Task[Unit] =
+      isClosedRef.get.ifM(
+        Task.unit,
+        maybeMessage match {
+          case Attempt.Successful(message) =>
+            Task.deferFuture(messageSubject.onNext(MessageReceived(message))).void
+          case Attempt.Failure(err) =>
+            Task(logger.debug(s"Message decoding failed due to ${err}", err)) >>
+              Task.deferFuture(messageSubject.onNext(DecodingError)).void
+        }
+      )
+
+    def handleError(error: Throwable): Task[Unit] =
+      isClosedRef.get.ifM(
+        Task.unit,
+        Task.deferFuture(messageSubject.onNext(UnexpectedError(error))).void
+      )
+
+    private def close() =
+      for {
+        _ <- isClosedRef.set(true)
+        _ = messageSubject.onComplete()
+      } yield ()
+  }
+
+  private object ChannelImpl {
+    def apply[M: Codec](
+        nettyChannel: io.netty.channel.Channel,
+        localAddress: InetSocketAddress,
+        remoteAddress: InetSocketAddress
+    )(implicit scheduler: Scheduler): Resource[Task, ChannelImpl[M]] =
+      Resource.make {
+        for {
+          isClosedRef <- Ref[Task].of(false)
+          channel = new ChannelImpl[M](
+            nettyChannel,
+            localAddress,
+            remoteAddress,
+            ConnectableSubject[ChannelEvent[M]](),
+            isClosedRef
+          )
+        } yield channel
+      }(_.close())
+  }
+
+  private implicit class TaskExecutionOps(task: Task[Unit]) {
+
+    /** Execute a task synchronously on the channel's event loop.
+      * Since we know we only have once channel this will always
+      * just execute one thing at a time.
+      */
+    def executeOn(ctx: ChannelHandlerContext): Unit =
+      task.runSyncUnsafe()(Scheduler(ctx.channel.eventLoop), implicitly[CanBlock])
+  }
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -30,7 +30,7 @@ import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.DatagramPacket
 import io.netty.channel.socket.nio.NioDatagramChannel
 import java.io.IOException
-import java.net.{InetSocketAddress, PortUnreachableException}
+import java.net.InetSocketAddress
 import monix.eval.Task
 import monix.execution.Scheduler
 import scala.util.control.NonFatal
@@ -253,17 +253,10 @@ class StaticUDPPeerGroup[M] private (
                 val channelId = ctx.channel().id()
                 val remoteAddress = ctx.channel.remoteAddress().asInstanceOf[InetSocketAddress]
                 cause match {
-                  case _: PortUnreachableException =>
-                    // We do not want ugly exception, but we do not close the channel,
-                    // it is entirely up to user to close not responding channels.
-                    logger.info(s"Peer with ip $remoteAddress not available")
-                  case _ =>
-                    super.exceptionCaught(ctx, cause)
-                }
-                cause match {
                   case NonFatal(ex) =>
                     handleError(remoteAddress, ex)
                 }
+                super.exceptionCaught(ctx, cause)
               }
             })
 

--- a/scalanet/test/resources/logback-test.xml
+++ b/scalanet/test/resources/logback-test.xml
@@ -7,6 +7,8 @@
         </encoder>
     </appender>
 
+    <logger name="io.netty" level="OFF"/>
+
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
@@ -4,15 +4,9 @@ import java.net._
 import java.nio.ByteBuffer
 import java.security.KeyStore
 import java.security.cert.Certificate
-import cats.effect.Resource
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils
-import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
-import monix.execution.Scheduler
-import monix.eval.Task
-import scodec.Codec
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration._
 import scala.util.Random
 
 object NetUtils {
@@ -82,35 +76,5 @@ object NetUtils {
     val a = new Array[Byte](n)
     Random.nextBytes(a)
     a
-  }
-
-  def randomUDPPeerGroup[M](
-      implicit scheduler: Scheduler,
-      codec: Codec[M]
-  ): Resource[Task, DynamicUDPPeerGroup[M]] =
-    DynamicUDPPeerGroup(DynamicUDPPeerGroup.Config(aRandomAddress()))
-
-  def withTwoRandomUDPPeerGroups[M](
-      testCode: (DynamicUDPPeerGroup[M], DynamicUDPPeerGroup[M]) => Task[_]
-  )(implicit scheduler: Scheduler, codec: Codec[M]): Unit = {
-    (for {
-      pg1 <- randomUDPPeerGroup
-      pg2 <- randomUDPPeerGroup
-    } yield (pg1, pg2))
-      .use {
-        case (pg1, pg2) =>
-          testCode(pg1, pg2).void
-      }
-      .runSyncUnsafe(15.seconds)
-  }
-
-  def withARandomUDPPeerGroup[M](
-      testCode: DynamicUDPPeerGroup[M] => Task[_]
-  )(implicit scheduler: Scheduler, codec: Codec[M]): Unit = {
-    randomUDPPeerGroup
-      .use { pg =>
-        testCode(pg).void
-      }
-      .runSyncUnsafe(15.seconds)
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/NetUtils.scala
@@ -61,6 +61,7 @@ object NetUtils {
     val socket = new ServerSocket(address.getPort, 0, InetAddress.getLoopbackAddress)
     try {
       testCode(address)
+      ()
     } finally {
       socket.close()
     }
@@ -71,6 +72,7 @@ object NetUtils {
     val address = socket.getLocalSocketAddress.asInstanceOf[InetSocketAddress]
     try {
       testCode(address)
+      ()
     } finally {
       socket.close()
     }
@@ -97,7 +99,7 @@ object NetUtils {
     } yield (pg1, pg2))
       .use {
         case (pg1, pg2) =>
-          testCode(pg1, pg2)
+          testCode(pg1, pg2).void
       }
       .runSyncUnsafe(15.seconds)
   }
@@ -107,7 +109,7 @@ object NetUtils {
   )(implicit scheduler: Scheduler, codec: Codec[M]): Unit = {
     randomUDPPeerGroup
       .use { pg =>
-        testCode(pg)
+        testCode(pg).void
       }
       .runSyncUnsafe(15.seconds)
   }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/PeerUtils.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/PeerUtils.scala
@@ -37,9 +37,11 @@ trait PeerUtils[A, M, PG[_, _]] {
     initialize(bob).runToFuture
     try {
       testFunction(alice, bob)
+      ()
     } finally {
       shutdown(alice).runToFuture
       shutdown(bob).runToFuture
+      ()
     }
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/StandardTestPack.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/StandardTestPack.scala
@@ -20,7 +20,7 @@ object StandardTestPack {
     val alicesMessage = Random.alphanumeric.take(1024).mkString
     val bobsMessage = Random.alphanumeric.take(1024).mkString
 
-    for {
+    (for {
       bobReceiver <- bob.server.collectChannelCreated
         .mapEval {
           case (channel, release) =>
@@ -46,7 +46,11 @@ object StandardTestPack {
       _ <- aliceClient._1.sendMessage(alicesMessage)
 
       _ = aliceClient._1.in.connect()
-      _ = bob.server.collectChannelCreated.foreach(_._1.in.connect())
+      _ = bob.server.collectChannelCreated.foreach {
+        case (channel, _) =>
+          channel.in.connect()
+          ()
+      }
       _ = bob.server.connect()
 
       bobReceived <- bobReceiver.join
@@ -55,7 +59,7 @@ object StandardTestPack {
     } yield {
       bobReceived shouldBe alicesMessage
       aliceReceived shouldBe bobsMessage
-    }
+    }).void
   }
 
   // Test that Alice can send messages to Bob concurrently and receive answers on both channels.
@@ -65,7 +69,7 @@ object StandardTestPack {
     val alicesMessage = Random.alphanumeric.take(1024).mkString
     val bobsMessage = Random.alphanumeric.take(1024).mkString
 
-    for {
+    (for {
       _ <- bob.server.collectChannelCreated.foreachL {
         case (channel, release) => channel.sendMessage(bobsMessage).guarantee(release).runAsyncAndForget
       }.startAndForget
@@ -80,7 +84,11 @@ object StandardTestPack {
 
       _ = aliceClient1._1.in.connect()
       _ = aliceClient2._1.in.connect()
-      _ = bob.server.collectChannelCreated.foreach(channel => channel._1.in.connect())
+      _ = bob.server.collectChannelCreated.foreach {
+        case (channel, _) =>
+          channel.in.connect()
+          ()
+      }
       _ = bob.server.connect()
 
       aliceReceived1 <- aliceReceiver1.join
@@ -90,7 +98,7 @@ object StandardTestPack {
     } yield {
       aliceReceived1 shouldBe bobsMessage
       aliceReceived2 shouldBe bobsMessage
-    }
+    }).void
   }
 
   def shouldErrorForMessagingAnInvalidAddress[A](alice: PeerGroup[A, String], invalidAddress: A)(
@@ -102,5 +110,6 @@ object StandardTestPack {
     }
 
     aliceError.futureValue.to shouldBe invalidAddress
+    ()
   }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/TransportPeerGroupAsyncSpec.scala
@@ -26,6 +26,7 @@ class TransportPeerGroupAsyncSpec extends AsyncFlatSpec with BeforeAndAfterAll {
   override def afterAll(): Unit = {
     threadPool.shutdown()
     threadPool.awaitTermination(60, TimeUnit.SECONDS)
+    ()
   }
 
   private val rpcs = Table(

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroupSpec.scala
@@ -1,0 +1,24 @@
+package io.iohk.scalanet.peergroup.udp
+
+import cats.effect.Resource
+import java.net.InetSocketAddress
+import monix.eval.Task
+import monix.execution.Scheduler
+import scodec.Codec
+import io.iohk.scalanet.peergroup.PeerGroup
+import io.iohk.scalanet.peergroup.InetMultiAddress
+
+class DynamicUDPPeerGroupSpec extends UDPPeerGroupSpec("DynamicUDPPPeerGroup") {
+  override def initUdpPeerGroup[M](
+      address: InetSocketAddress
+  )(implicit s: Scheduler, c: Codec[M]): Resource[Task, UDPPeerGroupSpec.TestGroup[M]] = {
+    DynamicUDPPeerGroup[M](DynamicUDPPeerGroup.Config(address)).map { pg =>
+      new PeerGroup[InetMultiAddress, M] {
+        override def processAddress = pg.processAddress
+        override def server = pg.server
+        override def client(to: InetMultiAddress) = pg.client(to)
+        def channelCount: Int = pg.activeChannels.size
+      }
+    }
+  }
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
@@ -123,7 +123,10 @@ class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") with
       .use {
         case (pg1, client21, client31a, client31b) =>
           for {
-            _ <- runEchoServer(pg1).startAndForget
+            // Not releasing the incoming channel immediately because then it may or may not
+            // be there when the next message arrives on another channel. In this test we
+            // want to show that if there are two client channels they both see the messages.
+            _ <- runEchoServer(pg1, doRelease = false).startAndForget
 
             _ <- client21.sendMessage("Two to One")
             _ <- client31a.sendMessage("Three to One A")

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
@@ -94,7 +94,8 @@ class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") with
                     .start
 
                   // Send 3 messages, which should result in two incoming channels emitted.
-                  _ <- List.range(0, 3).traverse(i => client12.sendMessage(i.toString))
+                  // Allow some time between them so the third message doesn't end up in the first channel that gets released.
+                  _ <- List.range(0, 3).traverse(i => client12.sendMessage(i.toString).delayExecution(50.millis))
 
                   // Give the server time to process all messages
                   _ <- Task(messageCounter.await(timeout.toMillis, TimeUnit.MILLISECONDS))

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
@@ -3,14 +3,23 @@ package io.iohk.scalanet.peergroup.udp
 import cats.effect.Resource
 import cats.implicits._
 import java.net.InetSocketAddress
+import java.util.concurrent.CountDownLatch
 import monix.execution.Scheduler
 import monix.eval.Task
-import scodec.Codec
 import io.iohk.scalanet.peergroup.PeerGroup
 import io.iohk.scalanet.peergroup.InetMultiAddress
+import io.iohk.scalanet.peergroup.Channel.MessageReceived
+import org.scalatest.Matchers
+import scodec.Codec
 import scodec.codecs.implicits._
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+import io.iohk.scalanet.peergroup.Channel
 
-class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") {
+class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") with Matchers {
+  import UDPPeerGroupSpec.runEchoServer
+
+  val timeout = 15.seconds
 
   override def initUdpPeerGroup[M](
       address: InetSocketAddress
@@ -25,17 +34,136 @@ class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") {
     }
   }
 
-  it should "use the server port when it opens client channels" in {
-    List
-      .fill(2)(initUdpPeerGroup[String]())
-      .sequence
-      .use {
-        case List(pg1, pg2) =>
-          ???
+  def startCollectingMessages(timespan: FiniteDuration)(channel: Channel[InetMultiAddress, String]) =
+    channel.in.refCount
+      .collect {
+        case MessageReceived(msg) => msg
       }
-      .runSyncUnsafe()
+      .takeByTimespan(timespan)
+      .toListL
+      .start
+
+  it should "use the server port when it opens client channels" in {
+    (for {
+      pg1 <- initUdpPeerGroup[String]()
+      pg2 <- initUdpPeerGroup[String]()
+      client12 <- pg1.client(pg2.processAddress)
+    } yield (pg1, pg2, client12))
+      .use {
+        case (pg1, pg2, client12) =>
+          for {
+            _ <- client12.sendMessage("Hola!")
+            event <- pg2.server.refCount.collectChannelCreated.headL
+          } yield {
+            event._1.to shouldBe pg1.processAddress
+          }
+      }
+      .runSyncUnsafe(timeout)
   }
 
-  it should "replicate incoming messages to all channels connected to the remote address" in (pending)
-  it should "re-emit a server event if a closed channel is re-activated" in (pending)
+  it should "re-emit a server event if a closed channel is re-activated" in {
+    initUdpPeerGroup[String]().allocated
+      .flatMap {
+        case (pg2, pg2Release) =>
+          (for {
+            pg1 <- initUdpPeerGroup[String]()
+            client12 <- pg1.client(pg2.processAddress)
+          } yield (pg1, client12))
+            .use {
+              case (pg1, client12) =>
+                val messageCounter = new CountDownLatch(3)
+                for {
+                  // Close incoming channel after two messages and collect which ports they came from.
+                  // Further messages should result in another incoming channel being created.
+                  listener <- pg2.server.refCount.collectChannelCreated
+                    .mapEval {
+                      case (channel, release) =>
+                        channel.in.refCount
+                          .collect {
+                            case MessageReceived(_) =>
+                              messageCounter.countDown()
+                          }
+                          .take(2)
+                          .completedL
+                          .guarantee(release)
+                          // Have to do it in the background otherwise it would block the processing of incoming UDP packets..
+                          .startAndForget
+                          .as(channel.to)
+                    }
+                    .toListL
+                    .start
+
+                  // Send 3 messages, which should result in two incoming channels emitted.
+                  _ <- List.range(0, 3).traverse(i => client12.sendMessage(i.toString))
+
+                  // Give the server time to process all messages
+                  _ <- Task(messageCounter.await(timeout.toMillis, TimeUnit.MILLISECONDS))
+                  // Release so the server topic is closed and we get the results.
+                  _ <- pg2Release
+                  ports <- listener.join
+
+                } yield {
+                  ports shouldBe List(pg1.processAddress, pg1.processAddress)
+                }
+            }
+      }
+      .runSyncUnsafe(timeout)
+  }
+
+  it should "replicate incoming messages to all client channels connected to the remote address" in {
+    (for {
+      pg1 <- initUdpPeerGroup[String]()
+      pg2 <- initUdpPeerGroup[String]()
+      pg3 <- initUdpPeerGroup[String]()
+      client21 <- pg2.client(pg1.processAddress)
+      client31a <- pg3.client(pg1.processAddress)
+      client31b <- pg3.client(pg1.processAddress)
+    } yield (pg1, client21, client31a, client31b))
+      .use {
+        case (pg1, client21, client31a, client31b) =>
+          for {
+            _ <- runEchoServer(pg1).startAndForget
+
+            _ <- client21.sendMessage("Two to One")
+            _ <- client31a.sendMessage("Three to One A")
+            _ <- client31b.sendMessage("Three to One B")
+
+            receivers <- List(client21, client31a, client31b).traverse(startCollectingMessages(1.second))
+            received <- receivers.traverse(_.join)
+          } yield {
+            received(0) shouldBe List("Two to One")
+            received(1) shouldBe List("Three to One A", "Three to One B")
+            received(2) shouldBe received(1)
+          }
+      }
+      .runSyncUnsafe(timeout)
+  }
+
+  it should "replicate incoming messages to clients as well as the server channel" in {
+    (for {
+      pg1 <- initUdpPeerGroup[String]()
+      pg2 <- initUdpPeerGroup[String]()
+      client21 <- pg2.client(pg1.processAddress)
+    } yield (pg1, pg2, client21))
+      .use {
+        case (pg1, pg2, client21) =>
+          for {
+            _ <- runEchoServer(pg1).startAndForget
+
+            message = "Requests and responses look the same."
+            _ <- client21.sendMessage(message)
+
+            server21 <- pg2.server.refCount.collectChannelCreated.map {
+              case (channel, _) => channel
+            }.headL
+
+            receivers <- List(client21, server21).traverse(startCollectingMessages(1.second))
+            received <- receivers.traverse(_.join)
+          } yield {
+            received(0) shouldBe List(message)
+            received(1) shouldBe received(0)
+          }
+      }
+      .runSyncUnsafe(timeout)
+  }
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
@@ -1,14 +1,17 @@
 package io.iohk.scalanet.peergroup.udp
 
 import cats.effect.Resource
+import cats.implicits._
 import java.net.InetSocketAddress
 import monix.execution.Scheduler
 import monix.eval.Task
 import scodec.Codec
 import io.iohk.scalanet.peergroup.PeerGroup
 import io.iohk.scalanet.peergroup.InetMultiAddress
+import scodec.codecs.implicits._
 
 class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") {
+
   override def initUdpPeerGroup[M](
       address: InetSocketAddress
   )(implicit s: Scheduler, c: Codec[M]): Resource[Task, UDPPeerGroupSpec.TestGroup[M]] = {
@@ -22,6 +25,17 @@ class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") {
     }
   }
 
-  it should "use the server port for reach client it creates" in (pending)
+  it should "use the server port when it opens client channels" in {
+    List
+      .fill(2)(initUdpPeerGroup[String]())
+      .sequence
+      .use {
+        case List(pg1, pg2) =>
+          ???
+      }
+      .runSyncUnsafe()
+  }
+
   it should "replicate incoming messages to all channels connected to the remote address" in (pending)
+  it should "re-emit a server event if a closed channel is re-activated" in (pending)
 }

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroupSpec.scala
@@ -1,0 +1,27 @@
+package io.iohk.scalanet.peergroup.udp
+
+import cats.effect.Resource
+import java.net.InetSocketAddress
+import monix.execution.Scheduler
+import monix.eval.Task
+import scodec.Codec
+import io.iohk.scalanet.peergroup.PeerGroup
+import io.iohk.scalanet.peergroup.InetMultiAddress
+
+class StaticUDPPeerGroupSpec extends UDPPeerGroupSpec("StaticUDPPeerGroup") {
+  override def initUdpPeerGroup[M](
+      address: InetSocketAddress
+  )(implicit s: Scheduler, c: Codec[M]): Resource[Task, UDPPeerGroupSpec.TestGroup[M]] = {
+    StaticUDPPeerGroup[M](StaticUDPPeerGroup.Config(address)).map { pg =>
+      new PeerGroup[InetMultiAddress, M] {
+        override def processAddress = pg.processAddress
+        override def server = pg.server
+        override def client(to: InetMultiAddress) = pg.client(to)
+        def channelCount: Int = pg.channelCount.runSyncUnsafe()
+      }
+    }
+  }
+
+  it should "use the server port for reach client it creates" in (pending)
+  it should "replicate incoming messages to all channels connected to the remote address" in (pending)
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/udp/UDPPeerGroupSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/udp/UDPPeerGroupSpec.scala
@@ -1,4 +1,4 @@
-package io.iohk.scalanet.peergroup
+package io.iohk.scalanet.peergroup.udp
 
 import cats.implicits._
 import cats.effect.Resource
@@ -7,8 +7,10 @@ import io.iohk.scalanet.NetUtils._
 import io.iohk.scalanet.peergroup.Channel.{DecodingError, MessageReceived}
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.PeerGroup.{ChannelAlreadyClosedException, MessageMTUException}
+import io.iohk.scalanet.peergroup.{InetMultiAddress, PeerGroup, Channel}
 import io.iohk.scalanet.peergroup.StandardTestPack._
-import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
+import io.iohk.scalanet.peergroup.StandardTestPack
+import io.iohk.scalanet.peergroup.TestMessage
 import java.net.InetSocketAddress
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -21,12 +23,21 @@ import scodec.bits.ByteVector
 import scodec.Codec
 import scodec.codecs.implicits._
 
-class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
+abstract class UDPPeerGroupSpec[PG <: UDPPeerGroupSpec.TestGroup[_]](name: String)
+    extends FlatSpec
+    with EitherValues
+    with Eventually {
+  import scala.language.reflectiveCalls
+
   implicit val scheduler = Scheduler.fixedPool("test", 16)
 
   implicit val pc: PatienceConfig = PatienceConfig(5 seconds)
 
-  behavior of "UDPPeerGroup"
+  behavior of name
+
+  def initUdpPeerGroup[M](
+      address: InetSocketAddress = aRandomAddress()
+  )(implicit s: Scheduler, c: Codec[M]): Resource[Task, UDPPeerGroupSpec.TestGroup[M]]
 
   it should "report an error for sending a message greater than the MTU" in
     withARandomUDPPeerGroup[ByteVector] { alice =>
@@ -58,14 +69,12 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
     }
 
   it should "shutdown cleanly" in {
-    import UDPPeerGroupSpecUtils._
-
     (for {
       pg1nR <- initUdpPeerGroup[String]().allocated
       (pg1, release) = pg1nR
-      isListeningAfterStart <- Task.now(isListeningUDP(pg1.config.bindAddress))
+      isListeningAfterStart <- Task.now(isListeningUDP(pg1.processAddress.inetSocketAddress))
       _ <- release
-      isListeningAfterShutdown <- Task.now(isListeningUDP(pg1.config.bindAddress))
+      isListeningAfterShutdown <- Task.now(isListeningUDP(pg1.processAddress.inetSocketAddress))
     } yield {
       assert(isListeningAfterStart)
       assert(!isListeningAfterShutdown)
@@ -73,7 +82,6 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "throw InitializationError when port already in use" in {
-    import UDPPeerGroupSpecUtils._
     val address = aRandomAddress()
 
     initUdpPeerGroup[String](address)
@@ -87,7 +95,6 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "clean up closed channels" in {
-    import UDPPeerGroupSpecUtils._
     val messageFromClients = "Hello server"
     val randomNonExistingPeer = InetMultiAddress(aRandomAddress())
 
@@ -98,7 +105,7 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
         } >>
           Task {
             eventually {
-              pg1.activeChannels.size() shouldEqual 0
+              pg1.channelCount shouldEqual 0
             }
           }
       }
@@ -106,7 +113,7 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "echo request from clients received from several channels sequentially" in {
-    import UDPPeerGroupSpecUtils._
+    import UDPPeerGroupSpec._
     val messageFromClients = "Hello server"
     (for {
       pg1 <- initUdpPeerGroup[String]()
@@ -116,7 +123,9 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
       .use {
         case (pg1, pg2, pg3) =>
           for {
+            _ <- runDiscardServer(pg1).startAndForget
             _ <- runEchoServer(pg2).startAndForget
+            _ <- runDiscardServer(pg3).startAndForget
             response <- requestResponse(pg1, pg2.processAddress, messageFromClients)
             response1 <- requestResponse(pg3, pg2.processAddress, messageFromClients)
             response2 <- requestResponse(pg1, pg2.processAddress, messageFromClients)
@@ -126,10 +135,11 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
             response1 shouldEqual messageFromClients
             response2 shouldEqual messageFromClients
             response3 shouldEqual messageFromClients
+
             eventually {
-              assert(pg1.activeChannels.isEmpty)
-              assert(pg2.activeChannels.isEmpty)
-              assert(pg3.activeChannels.isEmpty)
+              assert(pg1.channelCount == 0)
+              assert(pg2.channelCount == 0)
+              assert(pg3.channelCount == 0)
             }
           }
       }
@@ -137,7 +147,7 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "echo request from several clients received from several channels in parallel" in {
-    import UDPPeerGroupSpecUtils._
+    import UDPPeerGroupSpec._
     val messageFromClients = "Hello server"
 
     List
@@ -146,6 +156,9 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
       .use {
         case List(pg1, pg2, pg3, pg4) =>
           for {
+            _ <- runDiscardServer(pg1).startAndForget
+            _ <- runDiscardServer(pg2).startAndForget
+            _ <- runDiscardServer(pg3).startAndForget
             _ <- runEchoServer(pg4).startAndForget
             responses <- Task.parZip3(
               requestResponse(pg1, pg4.processAddress, messageFromClients),
@@ -173,10 +186,10 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
             pg3Response1 shouldEqual messageFromClients
 
             eventually {
-              assert(pg1.activeChannels.isEmpty)
-              assert(pg2.activeChannels.isEmpty)
-              assert(pg3.activeChannels.isEmpty)
-              assert(pg4.activeChannels.isEmpty)
+              assert(pg1.channelCount == 0)
+              assert(pg2.channelCount == 0)
+              assert(pg3.channelCount == 0)
+              assert(pg4.channelCount == 0)
             }
 
           }
@@ -185,7 +198,6 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "inform user when trying to send message from already closed channel" in {
-    import UDPPeerGroupSpecUtils._
     val messageFromClients = "Hello server"
     val randomNonExistingPeer = InetMultiAddress(aRandomAddress())
 
@@ -206,7 +218,6 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 
   it should "inform user if there was decoding error on the channel" in {
-    import UDPPeerGroupSpecUtils._
     import scodec.codecs.implicits._
     (for {
       pg1 <- initUdpPeerGroup[String]()
@@ -231,7 +242,12 @@ class UDPPeerGroupSpec extends FlatSpec with EitherValues with Eventually {
   }
 }
 
-object UDPPeerGroupSpecUtils {
+object UDPPeerGroupSpec {
+  type HasChannels = {
+    def channelCount: Int
+  }
+  type TestGroup[M] = PeerGroup[InetMultiAddress, M] with HasChannels
+
   def requestResponse[M](
       peerGroup: PeerGroup[InetMultiAddress, M],
       to: InetMultiAddress,
@@ -259,8 +275,8 @@ object UDPPeerGroupSpecUtils {
     } yield response
   }
 
+  // echo server which closes every incoming channel after response
   def runEchoServer[M](peerGroup: PeerGroup[InetMultiAddress, M])(implicit s: Scheduler): Task[Unit] = {
-    // echo server which closes every incoming channel after response
     peerGroup.server.refCount.collectChannelCreated
       .mergeMap {
         case (channel, release) =>
@@ -276,10 +292,14 @@ object UDPPeerGroupSpecUtils {
       }
   }
 
-  def initUdpPeerGroup[M](
-      address: InetSocketAddress = aRandomAddress()
-  )(implicit s: Scheduler, c: Codec[M]): Resource[Task, DynamicUDPPeerGroup[M]] = {
-    DynamicUDPPeerGroup[M](DynamicUDPPeerGroup.Config(address))
+  // A server which dicards incoming messages and closes the channel.
+  // This is necessary for the StaticUDPPeerGroup because it creates a server channel
+  // for responses, which would stay open unless consumed.
+  def runDiscardServer[M](peerGroup: PeerGroup[InetMultiAddress, M])(implicit s: Scheduler): Task[Unit] = {
+    peerGroup.server.refCount.collectChannelCreated
+      .mapEval {
+        case (_, release) => release
+      }
+      .foreachL(_ => ())
   }
-
 }


### PR DESCRIPTION
Adds a `StaticUDPPeerGroup` that reuses the same local port for channels so that it can be compatible with Ethereum nodes.

I used cats effect concurrency primitives rather than concurrent collections, but in theory they could be implemented with the standard data structures, or even better with Monix Atomics, to avoid having to do the `runSyncUnsafe` in the channel handler; although I ended up using `runAsyncAndForget` since with UDP the ordering of messages doesn't matter. I figured if we want to use a `monix.catnap.ConcurrentQueue` then it will be inevitable to have effects, and the creation of the classes is effectful as well because of the concurrency primitives they use inside, such as Semaphore (which are good as they are non-blocking). 

Anyway, this is one way, I suggest that if we don't like it then we open another ticket to do it in another way and perhaps compare benchmarks. For now I think we can move on to implementing Kademlia.


I'm sorry about the syntactic noise I had to add after enabling warnings about discarded values. This was necessary because the compiler didn't complain about a case like `def handle(data: DatagramPacket): Unit = Task(whatever(data))` which would have left the task lost. At least it makes it clear where we're kicking off futures as well. But if you think it's not worth it, we can rely on tests and code reviews, I only wanted this to catch anything I forget in the Netty handlers. Or we can add an `ignore` function like F#.

