### PR TITLE
ETCM-163: Kademlia with Static UDP

### DIFF
--- a/scalanet/kademlia/it/resources/logback-test.xml
+++ b/scalanet/kademlia/it/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%t %0logger %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="OFF"/>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KBuckets.scala
+++ b/scalanet/kademlia/src/io/iohk/scalanet/kademlia/KBuckets.scala
@@ -161,7 +161,7 @@ class KBuckets private (
   }
 
   private def bucketToString(bucket: TimeSet[BitVector]): String = {
-    s"${bucket.iterator.map(id => s"(id=${id.toBin}, d=${Xor.d(id, baseId)})").mkString(", ")}"
+    s"${bucket.iterator.map(id => s"(id=${id.toBin} / ${id.toHex}, d=${Xor.d(id, baseId)})").mkString(", ")}"
   }
 
   private def bucketOp(nodeId: BitVector)(op: (Int, TimeSet[BitVector]) => KBuckets): KBuckets = {


### PR DESCRIPTION
Tests Kademlia with both static and dynamic UDP groups. The console app now uses the static one.

Builds on https://github.com/input-output-hk/scalanet/pull/92 see the [diff](https://github.com/input-output-hk/scalanet/compare/ETCM-170-message-queue...ETCM-163-kademlia-use-static-udp)

It took me a while to figure out why it didn't work with the `StaticUDPPeerGroup`. The reason was that the server channel handler awaited upon the first request coming from the client channel; while it waited no more incoming channels were processed. That worked fine with `DynamicUDPPeerGroup` because it always used a fresh channel for sending requests, so it never had to wait, however with the `StaticUDPPeerGroup` the premise is that we can't tell whether an incoming packet is a request or a response, so we pass both kinds to the server channels. This resulted in the responses coming from nodes, popping up as server channels, where they got filtered out, then timed out as there was no request coming, meanwhile holding up the accepting of real requests.

The solution is that we cannot block in the server channel handler.