### PR TITLE
ETCM-207: Discovery v4 Part2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -110,7 +110,10 @@ object scalanet extends ScalanetModule with PublishModule {
       override def moduleDeps: Seq[JavaModule] =
         super.moduleDeps ++ Seq(scalanet.test)
     }
-    object it extends TestModule
+    object it extends TestModule {
+      override def moduleDeps: Seq[JavaModule] =
+        super.moduleDeps ++ Seq(scalanet.test, scalanet.discovery.test)
+    }
   }
 
   object examples extends SubModule {

--- a/scalanet/discovery/it/resources/logback-test.xml
+++ b/scalanet/discovery/it/resources/logback-test.xml
@@ -3,13 +3,15 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%t %0logger %-5level %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="io.netty" level="OFF"/>
 
-    <root level="WARN">
+    <logger name="io.iohk.scalanet.peergroup.udp" level="ERROR"/>
+
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/scalanet/discovery/it/resources/logback-test.xml
+++ b/scalanet/discovery/it/resources/logback-test.xml
@@ -11,7 +11,7 @@
 
     <logger name="io.iohk.scalanet.peergroup.udp" level="ERROR"/>
 
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -1,16 +1,21 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
-import io.iohk.scalanet.kademlia.KademliaIntegrationSpec
-import io.iohk.scalanet.discovery.crypto.PublicKey
-import io.iohk.scalanet.discovery.hash.Hash
+import cats.effect.Resource
+import io.iohk.scalanet.discovery.crypto.{PublicKey, PrivateKey}
+import io.iohk.scalanet.discovery.crypto.SigAlg
+import io.iohk.scalanet.discovery.ethereum.EthereumNodeRecord
 import io.iohk.scalanet.discovery.ethereum.Node
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
-import monix.eval.Task
-import io.iohk.scalanet.discovery.crypto.SigAlg
-import io.iohk.scalanet.NetUtils
-import scodec.bits.BitVector
+import io.iohk.scalanet.discovery.hash.Hash
+import io.iohk.scalanet.kademlia.KademliaIntegrationSpec
 import io.iohk.scalanet.kademlia.XorOrdering
-import cats.effect.Resource
+import io.iohk.scalanet.NetUtils
+import io.iohk.scalanet.peergroup.InetMultiAddress
+import io.iohk.scalanet.peergroup.udp.StaticUDPPeerGroup
+import java.net.InetSocketAddress
+import monix.eval.Task
+import scala.concurrent.duration._
+import scodec.bits.BitVector
 
 class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("DiscoveryService with StaticUDPPeerGroup") {
   override type PeerRecord = Node
@@ -23,20 +28,62 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
       service.getNodes.map(_.toSeq)
   }
 
+  // Using fake crypto and scodec encoding instead of RLP.
   implicit val sigalg: SigAlg = new MockSigAlg()
+  import io.iohk.scalanet.discovery.ethereum.codecs.DefaultCodecs._
 
-  override def generatePeerRecord(): Node = {
+  override def generatePeerRecordWithKey() = {
     val address = NetUtils.aRandomAddress
-    val (publicKey, _) = sigalg.newKeyPair
-    Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
+    val (publicKey, privateKey) = sigalg.newKeyPair
+    val node = Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
+    node -> privateKey
   }
 
   override def makeXorOrdering(nodeId: BitVector): Ordering[Node] =
     XorOrdering[Node, Hash](_.kademliaId)(Node.kademliaId(PublicKey(nodeId)))
 
   override def startNode(
-      selfRecord: PeerRecord,
-      initialNodes: Set[PeerRecord],
+      selfRecordWithKey: (Node, PrivateKey),
+      initialNodes: Set[Node],
       testConfig: TestNodeKademliaConfig
-  ): Resource[Task, TestNode] = ???
+  ): Resource[Task, TestNode] = {
+    val (selfNode, privateKey) = selfRecordWithKey
+    for {
+      peerGroup <- StaticUDPPeerGroup[Packet](
+        StaticUDPPeerGroup.Config(
+          bindAddress = nodeAddressToInetMultiAddress(selfNode.address).inetSocketAddress
+        )
+      )
+      config = DiscoveryConfig.default.copy(
+        requestTimeout = 1.second,
+        kademliaTimeout = 2.seconds
+      )
+      network <- Resource.liftF {
+        DiscoveryNetwork[InetMultiAddress](
+          peerGroup,
+          privateKey,
+          toNodeAddress = inetMultiAddressToNodeAddress,
+          config = config
+        )
+      }
+      selfEnr = EthereumNodeRecord.fromNode(selfNode, privateKey, seq = 1).require
+      service <- DiscoveryService[InetMultiAddress](
+        privateKey,
+        node = selfNode,
+        enr = selfEnr,
+        config = config,
+        bootstraps = initialNodes,
+        network = network,
+        toAddress = nodeAddressToInetMultiAddress
+      )
+    } yield new DiscoveryTestNode(selfNode, service)
+  }
+
+  def inetMultiAddressToNodeAddress(address: InetMultiAddress): Node.Address = {
+    val addr = address.inetSocketAddress
+    Node.Address(addr.getAddress, addr.getPort, addr.getPort)
+  }
+
+  def nodeAddressToInetMultiAddress(address: Node.Address): InetMultiAddress =
+    InetMultiAddress(new InetSocketAddress(address.ip, address.udpPort))
 }

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -66,6 +66,7 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
         DiscoveryNetwork[InetMultiAddress](
           peerGroup,
           privateKey,
+          localNodeAddress = selfNode.address,
           toNodeAddress = inetMultiAddressToNodeAddress,
           config = config
         )

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -1,0 +1,40 @@
+package io.iohk.scalanet.discovery.ethereum.v4
+
+import io.iohk.scalanet.kademlia.KademliaIntegrationSpec
+import io.iohk.scalanet.discovery.ethereum.Node
+import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
+import monix.eval.Task
+import io.iohk.scalanet.discovery.crypto.SigAlg
+import io.iohk.scalanet.NetUtils
+import scodec.bits.BitVector
+import io.iohk.scalanet.kademlia.XorOrdering
+import cats.effect.Resource
+
+class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("DiscoveryService with StaticUDPPeerGroup") {
+  override type PeerRecord = Node
+
+  class DiscoveryTestNode(
+      override val self: Node,
+      service: DiscoveryService
+  ) extends TestNode {
+    override def getPeers: Task[Seq[Node]] =
+      service.getNodes.map(_.toSeq)
+  }
+
+  implicit val sigalg: SigAlg = new MockSigAlg()
+
+  override def generatePeerRecord(): Node = {
+    val address = NetUtils.aRandomAddress
+    val (publicKey, _) = sigalg.newKeyPair
+    Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
+  }
+
+  override def makeXorOrdering(baseId: BitVector): Ordering[Node] =
+    XorOrdering[Node](baseId)(_.id)
+
+  override def startNode(
+      selfRecord: PeerRecord,
+      initialNodes: Set[PeerRecord],
+      testConfig: TestNodeKademliaConfig
+  ): Resource[Task, TestNode] = ???
+}

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -1,6 +1,8 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
 import io.iohk.scalanet.kademlia.KademliaIntegrationSpec
+import io.iohk.scalanet.discovery.crypto.PublicKey
+import io.iohk.scalanet.discovery.hash.Hash
 import io.iohk.scalanet.discovery.ethereum.Node
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
 import monix.eval.Task
@@ -29,8 +31,8 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
     Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
   }
 
-  override def makeXorOrdering(baseId: BitVector): Ordering[Node] =
-    XorOrdering[Node](_.id)(baseId)
+  override def makeXorOrdering(nodeId: BitVector): Ordering[Node] =
+    XorOrdering[Node, Hash](_.kademliaId)(Node.kademliaId(PublicKey(nodeId)))
 
   override def startNode(
       selfRecord: PeerRecord,

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -30,7 +30,7 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
   }
 
   override def makeXorOrdering(baseId: BitVector): Ordering[Node] =
-    XorOrdering[Node](baseId)(_.id)
+    XorOrdering[Node](_.id)(baseId)
 
   override def startNode(
       selfRecord: PeerRecord,

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -59,7 +59,8 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
         kademliaTimeout = 2.seconds,
         kademliaAlpha = testConfig.alpha,
         kademliaBucketSize = testConfig.k,
-        discoveryPeriod = testConfig.refreshRate
+        discoveryPeriod = testConfig.refreshRate,
+        knownPeers = initialNodes
       )
       network <- Resource.liftF {
         DiscoveryNetwork[InetMultiAddress](
@@ -75,7 +76,6 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
         node = selfNode,
         enr = selfEnr,
         config = config,
-        bootstraps = initialNodes,
         network = network,
         toAddress = nodeAddressToInetMultiAddress
       )

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -56,7 +56,10 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
       )
       config = DiscoveryConfig.default.copy(
         requestTimeout = 1.second,
-        kademliaTimeout = 2.seconds
+        kademliaTimeout = 2.seconds,
+        kademliaAlpha = testConfig.alpha,
+        kademliaBucketSize = testConfig.k,
+        discoveryPeriod = testConfig.refreshRate
       )
       network <- Resource.liftF {
         DiscoveryNetwork[InetMultiAddress](

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -55,8 +55,8 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
         )
       )
       config = DiscoveryConfig.default.copy(
-        requestTimeout = 1.second,
-        kademliaTimeout = 2.seconds,
+        requestTimeout = 500.millis,
+        kademliaTimeout = 100.millis, // We won't get that many results and waiting for them is slow.
         kademliaAlpha = testConfig.alpha,
         kademliaBucketSize = testConfig.k,
         discoveryPeriod = testConfig.refreshRate,

--- a/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KRouterKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KRouterKademliaIntegrationSpec.scala
@@ -1,0 +1,97 @@
+package io.iohk.scalanet.kademlia
+
+import java.security.SecureRandom
+import cats.effect.Resource
+import io.iohk.scalanet.kademlia.KNetwork.KNetworkScalanetImpl
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
+import io.iohk.scalanet.peergroup.{InetMultiAddress, InetPeerGroupUtils}
+import monix.eval.Task
+
+import io.iohk.scalanet.peergroup.PeerGroup
+import scodec.bits.BitVector
+
+abstract class KRouterKademliaIntegrationSpec(peerGroupName: String)
+    extends KademliaIntegrationSpec(s"KRouter and $peerGroupName") {
+
+  override type PeerRecord = NodeRecord[InetMultiAddress]
+
+  override def generatePeerRecord(): PeerRecord = {
+    val randomGen = new SecureRandom()
+    val testBitLength = 16
+    val address = InetMultiAddress(InetPeerGroupUtils.aRandomAddress())
+    val id = KBuckets.generateRandomId(testBitLength, randomGen)
+    NodeRecord(id, address, address)
+  }
+
+  override def makeXorOrdering(baseId: BitVector): Ordering[NodeRecord[InetMultiAddress]] =
+    XorNodeOrdering(baseId)
+
+  import io.iohk.scalanet.codec.DefaultCodecs._
+  import io.iohk.scalanet.kademlia.codec.DefaultCodecs._
+  implicit val codec = implicitly[scodec.Codec[KMessage[InetMultiAddress]]]
+
+  class KRouterTestNode(
+      override val self: PeerRecord,
+      router: KRouter[InetMultiAddress]
+  ) extends TestNode {
+    override def getPeers: Task[Seq[NodeRecord[InetMultiAddress]]] = {
+      router.nodeRecords.map(_.values.toSeq)
+    }
+  }
+
+  def makePeerGroup(
+      selfRecord: NodeRecord[InetMultiAddress]
+  ): Resource[Task, PeerGroup[InetMultiAddress, KMessage[InetMultiAddress]]]
+
+  private def startRouter(
+      selfRecord: NodeRecord[InetMultiAddress],
+      routerConfig: KRouter.Config[InetMultiAddress]
+  ): Resource[Task, KRouter[InetMultiAddress]] = {
+    for {
+      peerGroup <- makePeerGroup(selfRecord)
+      kademliaNetwork = new KNetworkScalanetImpl(peerGroup)
+      router <- Resource.liftF(KRouter.startRouterWithServerPar(routerConfig, kademliaNetwork))
+    } yield router
+  }
+
+  override def startNode(
+      selfRecord: PeerRecord,
+      initialNodes: Set[PeerRecord],
+      testConfig: TestNodeKademliaConfig
+  ): Resource[Task, TestNode] = {
+    val routerConfig = KRouter.Config(
+      selfRecord,
+      initialNodes,
+      alpha = testConfig.alpha,
+      k = testConfig.k,
+      serverBufferSize = testConfig.serverBufferSize,
+      refreshRate = testConfig.refreshRate
+    )
+    for {
+      router <- startRouter(selfRecord, routerConfig)
+    } yield new KRouterTestNode(selfRecord, router)
+  }
+
+}
+
+class StaticUDPKRouterKademliaIntegrationSpec extends KRouterKademliaIntegrationSpec("StaticUDP") {
+  import io.iohk.scalanet.peergroup.udp.StaticUDPPeerGroup
+
+  override def makePeerGroup(
+      selfRecord: NodeRecord[InetMultiAddress]
+  ) = {
+    val udpConfig = StaticUDPPeerGroup.Config(selfRecord.routingAddress.inetSocketAddress, channelCapacity = 100)
+    StaticUDPPeerGroup[KMessage[InetMultiAddress]](udpConfig)
+  }
+}
+
+class DynamicUDPKRouterKademliaIntegrationSpec extends KRouterKademliaIntegrationSpec("DynamicUDP") {
+  import io.iohk.scalanet.peergroup.udp.DynamicUDPPeerGroup
+
+  override def makePeerGroup(
+      selfRecord: NodeRecord[InetMultiAddress]
+  ) = {
+    val udpConfig = DynamicUDPPeerGroup.Config(selfRecord.routingAddress.inetSocketAddress, channelCapacity = 100)
+    DynamicUDPPeerGroup[KMessage[InetMultiAddress]](udpConfig)
+  }
+}

--- a/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -75,7 +75,7 @@ abstract class KademliaIntegrationSpec(name: String)
 
   behavior of s"Kademlia with $name"
 
-  ignore should "only find self node when there are no bootstrap nodes" in taskTestCase {
+  it should "only find self node when there are no bootstrap nodes" in taskTestCase {
     startNode().use { node =>
       node.getPeers.map { knownNodes =>
         knownNodes should have size 1
@@ -83,7 +83,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "enable finding nodes with common bootstrap node" in taskTestCase {
+  it should "enable finding nodes with common bootstrap node" in taskTestCase {
     (for {
       node <- startNode()
       node1 <- startNode(initialNodes = Set(node.self))
@@ -98,7 +98,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "enable discovering neighbours of boostrap node" in taskTestCase {
+  it should "enable discovering neighbours of boostrap node" in taskTestCase {
     (for {
       node <- startNode()
       node1 <- startNode()
@@ -111,7 +111,7 @@ abstract class KademliaIntegrationSpec(name: String)
           eventually {
             // node3 joins 3 others, and get joined by node4
             node3.getPeers.runSyncUnsafe().size shouldEqual 5
-            // node4 joins node3 so ignore should learn about all its peers
+            // node4 joins node3 so it should learn about all its peers
             node4.getPeers.runSyncUnsafe().size shouldEqual 5
 
             // These nodes received messages from node3 and node4 so they should add them to their routing tables,
@@ -125,7 +125,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "enable discovering neighbours of the neighbours" in taskTestCase {
+  it should "enable discovering neighbours of the neighbours" in taskTestCase {
     (for {
       node <- startNode()
       node1 <- startNode(initialNodes = Set(node.self))
@@ -143,7 +143,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "add only online nodes to routing table" in taskTestCase {
+  it should "add only online nodes to routing table" in taskTestCase {
     (for {
       node <- startNode()
       node1A <- Resource.liftF(startNode().allocated)
@@ -163,7 +163,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "refresh routing table" in taskTestCase {
+  it should "refresh routing table" in taskTestCase {
     val lowRefConfig = defaultConfig.copy(refreshRate = 3.seconds)
     val randomNode = generatePeerRecordWithKey
     (for {
@@ -184,7 +184,6 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  // FIXME
   it should "refresh table with many nodes in the network " in taskTestCase {
     val lowRefConfig = defaultConfig.copy(refreshRate = 1.seconds)
     val randomNode = generatePeerRecordWithKey
@@ -213,7 +212,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "add to routing table multiple concurrent nodes" in taskTestCase {
+  it should "add to routing table multiple concurrent nodes" in taskTestCase {
     val nodesRound1 = List.fill(5)(generatePeerRecordWithKey)
     val nodesRound2 = List.fill(5)(generatePeerRecordWithKey)
     (for {
@@ -229,7 +228,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  ignore should "finish lookup when k closest nodes are found" in taskTestCase {
+  it should "finish lookup when k closest nodes are found" in taskTestCase {
     // alpha = 1 makes sure we are adding nodes one by one, so the final count should be equal exactly k, if alpha > 1
     // then final count could be at least k.
     val lowKConfig = defaultConfig.copy(k = 3, alpha = 1)

--- a/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -29,7 +29,7 @@ abstract class KademliaIntegrationSpec(name: String)
     def getPeers: Task[Seq[PeerRecord]]
   }
 
-  def makeXorOrdering(baseId: BitVector): Ordering[PeerRecord]
+  def makeXorOrdering(nodeId: BitVector): Ordering[PeerRecord]
 
   /** Generate a random peer. */
   def generatePeerRecord(): PeerRecord

--- a/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -228,7 +228,7 @@ abstract class KademliaIntegrationSpec(peerGroupName: String)
     val lowKConfig = defaultConfig.copy(k = 3, alpha = 1)
     val nodes = (0 until 5).map(_ => generateNodeRecord()).toSeq
     val testNode = nodes.head
-    val rest = nodes.tail.sorted(ord = new XorNodeOrdering[InetMultiAddress](testNode.id))
+    val rest = nodes.tail.sorted(ord = XorNodeOrdering[InetMultiAddress](testNode.id))
     val bootStrapNode = rest.head
     val bootStrapNodeNeighbours = rest.tail.toSet
 

--- a/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/kademlia/KademliaIntegrationSpec.scala
@@ -143,7 +143,6 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  // FIXME
   ignore should "add only online nodes to routing table" in taskTestCase {
     (for {
       node <- startNode()
@@ -164,8 +163,7 @@ abstract class KademliaIntegrationSpec(name: String)
     }
   }
 
-  // FIXME
-  it should "refresh routing table" in taskTestCase {
+  ignore should "refresh routing table" in taskTestCase {
     val lowRefConfig = defaultConfig.copy(refreshRate = 3.seconds)
     val randomNode = generatePeerRecordWithKey
     (for {
@@ -187,7 +185,7 @@ abstract class KademliaIntegrationSpec(name: String)
   }
 
   // FIXME
-  ignore should "refresh table with many nodes in the network " in taskTestCase {
+  it should "refresh table with many nodes in the network " in taskTestCase {
     val lowRefConfig = defaultConfig.copy(refreshRate = 1.seconds)
     val randomNode = generatePeerRecordWithKey
     (for {

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
@@ -11,8 +11,30 @@ trait SigAlg {
   def SignatureBytesSize: Int
 
   def newKeyPair: (PublicKey, PrivateKey)
+
+  /** In the context of Secp256k1, produce a 65 byte signature
+    * as the concatenation of `r`, `s` and the recovery ID `v`. */
   def sign(privateKey: PrivateKey, data: BitVector): Signature
+
+  /** In the context of Secp256k1, remove the `v` recovery ID. */
+  def removeRecoveryId(signature: Signature): Signature
+
+  /** Verify that a signature is correct. It may or may not have a recovery ID. */
   def verify(publicKey: PublicKey, signature: Signature, data: BitVector): Boolean
+
+  /** Reverse engineer the public key from a signature, given the data that was signed.
+    * It can fail if the signature is incorrect.
+    */
   def recoverPublicKey(signature: Signature, data: BitVector): Attempt[PublicKey]
-  def toCompressedPublicKey(privateKey: PrivateKey): PublicKey
+
+  /** Produce the public key based on the private key. */
+  def toPublicKey(privateKey: PrivateKey): PublicKey
+
+  /** In the context of Secp256k1, the signature consists of a prefix byte
+    * followed by an `x` and `y` coordinate. Remove `y` and adjust the prefix
+    * to compress.
+    *
+    * See https://davidederosa.com/basic-blockchain-programming/elliptic-curve-keys
+    */
+  def compressPublicKey(publicKey: PublicKey): PublicKey
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
@@ -14,4 +14,5 @@ trait SigAlg {
   def sign(privateKey: PrivateKey, data: BitVector): Signature
   def verify(publicKey: PublicKey, signature: Signature, data: BitVector): Boolean
   def recoverPublicKey(signature: Signature, data: BitVector): Attempt[PublicKey]
+  def toCompressedPublicKey(privateKey: PrivateKey): PublicKey
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
@@ -11,5 +11,6 @@ trait SigAlg {
   def SignatureBytesSize: Int
 
   def sign(privateKey: PrivateKey, data: BitVector): Signature
+  def verify(publicKey: PublicKey, signature: Signature, data: BitVector): Boolean
   def recoverPublicKey(signature: Signature, data: BitVector): Attempt[PublicKey]
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/crypto/SigAlg.scala
@@ -10,6 +10,7 @@ trait SigAlg {
   def PublicKeyBytesSize: Int
   def SignatureBytesSize: Int
 
+  def newKeyPair: (PublicKey, PrivateKey)
   def sign(privateKey: PrivateKey, data: BitVector): Signature
   def verify(publicKey: PublicKey, signature: Signature, data: BitVector): Boolean
   def recoverPublicKey(signature: Signature, data: BitVector): Attempt[PublicKey]

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -15,6 +15,9 @@ case class EthereumNodeRecord(
 )
 
 object EthereumNodeRecord {
+  implicit val byteOrdering: Ordering[ByteVector] =
+    Ordering.by[ByteVector, Iterable[Byte]](_.toIterable)
+
   case class Content(
       // Nodes should increment this number whenever their properties change, like their address, and re-publish.
       seq: Long,
@@ -52,8 +55,7 @@ object EthereumNodeRecord {
 
   def fromNode(node: Node, privateKey: PrivateKey, seq: Long)(
       implicit sigalg: SigAlg,
-      codec: Codec[Content],
-      ordering: Ordering[ByteVector]
+      codec: Codec[Content]
   ): Attempt[EthereumNodeRecord] = {
     val content = Content(
       seq,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -62,8 +62,8 @@ object EthereumNodeRecord {
       SortedMap(
         Keys.id -> ByteVector("v4".getBytes(StandardCharsets.UTF_8)),
         Keys.ip -> ByteVector(node.address.ip.getAddress),
-        Keys.tcp -> ByteVector(node.address.tcpPort),
-        Keys.udp -> ByteVector(node.address.udpPort)
+        Keys.tcp -> ByteVector.fromInt(node.address.tcpPort),
+        Keys.udp -> ByteVector.fromInt(node.address.udpPort)
       )
     )
     codec.encode(content).map { data =>

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -66,9 +66,9 @@ object EthereumNodeRecord {
 
     val content = Content(
       seq,
-      // TODO: Compressed public key. We should be able to get it from the private key, but it's optional.
       SortedMap(
         Keys.id -> ByteVector("v4".getBytes(StandardCharsets.UTF_8)),
+        Keys.secp256k1 -> sigalg.toCompressedPublicKey(privateKey).toByteVector,
         ipKey -> ByteVector(node.address.ip.getAddress),
         tcpKey -> ByteVector.fromInt(node.address.tcpPort),
         udpKey -> ByteVector.fromInt(node.address.udpPort)

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -3,18 +3,24 @@ package io.iohk.scalanet.discovery.ethereum
 import scodec.bits.ByteVector
 import scala.collection.SortedMap
 import java.nio.charset.StandardCharsets
-import io.iohk.scalanet.discovery.crypto.Signature
+import io.iohk.scalanet.discovery.crypto.{Signature, PrivateKey, SigAlg}
+import scodec.{Codec, Attempt}
+import io.iohk.scalanet.discovery.crypto.PublicKey
 
 /** ENR corresponding to https://github.com/ethereum/devp2p/blob/master/enr.md */
 case class EthereumNodeRecord(
-    // Nodes should increment this number whenever their properties change, like their address, and re-publish.
-    seq: Long,
     // Signature over the record contents: [seq, k0, v0, k1, v1, ...]
     signature: Signature,
-    attrs: SortedMap[ByteVector, ByteVector]
+    content: EthereumNodeRecord.Content
 )
 
 object EthereumNodeRecord {
+  case class Content(
+      // Nodes should increment this number whenever their properties change, like their address, and re-publish.
+      seq: Long,
+      attrs: SortedMap[ByteVector, ByteVector]
+  )
+
   object Keys {
     private def key(k: String): ByteVector =
       ByteVector(k.getBytes(StandardCharsets.UTF_8))
@@ -42,5 +48,36 @@ object EthereumNodeRecord {
 
     /** IPv6-specific UDP port, big endian integer */
     val udp6 = key("udp6")
+  }
+
+  def fromNode(node: Node, privateKey: PrivateKey, seq: Long)(
+      implicit sigalg: SigAlg,
+      codec: Codec[Content],
+      ordering: Ordering[ByteVector]
+  ): Attempt[EthereumNodeRecord] = {
+    val content = Content(
+      seq,
+      // TODO: Compressed public key.
+      // TODO: IPv6 or IPv4?
+      SortedMap(
+        Keys.id -> ByteVector("v4".getBytes(StandardCharsets.UTF_8)),
+        Keys.ip -> ByteVector(node.address.ip.getAddress),
+        Keys.tcp -> ByteVector(node.address.tcpPort),
+        Keys.udp -> ByteVector(node.address.udpPort)
+      )
+    )
+    codec.encode(content).map { data =>
+      val sig = sigalg.sign(privateKey, data)
+      EthereumNodeRecord(sig, content)
+    }
+  }
+
+  def validateSignature(
+      enr: EthereumNodeRecord,
+      publicKey: PublicKey
+  )(implicit sigalg: SigAlg, codec: Codec[Content]): Attempt[Boolean] = {
+    codec.encode(enr.content).map { data =>
+      sigalg.verify(publicKey, enr.signature, data)
+    }
   }
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -68,14 +68,14 @@ object EthereumNodeRecord {
       seq,
       SortedMap(
         Keys.id -> ByteVector("v4".getBytes(StandardCharsets.UTF_8)),
-        Keys.secp256k1 -> sigalg.toCompressedPublicKey(privateKey).toByteVector,
+        Keys.secp256k1 -> sigalg.compressPublicKey(sigalg.toPublicKey(privateKey)).toByteVector,
         ipKey -> ByteVector(node.address.ip.getAddress),
         tcpKey -> ByteVector.fromInt(node.address.tcpPort),
         udpKey -> ByteVector.fromInt(node.address.udpPort)
       )
     )
     codec.encode(content).map { data =>
-      val sig = sigalg.sign(privateKey, data)
+      val sig = sigalg.removeRecoveryId(sigalg.sign(privateKey, data))
       EthereumNodeRecord(sig, content)
     }
   }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
@@ -26,7 +26,7 @@ object Node {
         tryParse[InetAddress](key)(bytes => InetAddress.getByAddress(bytes.toArray))
 
       def tryParsePort(key: ByteVector): Option[Int] =
-        tryParse[Int](key)(_.toInt())
+        tryParse[Int](key)(bytes => bytes.toInt())
 
       for {
         ip <- tryParseIP(Keys.ip6) orElse tryParseIP(Keys.ip)

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
@@ -2,6 +2,8 @@ package io.iohk.scalanet.discovery.ethereum
 
 import io.iohk.scalanet.discovery.crypto.PublicKey
 import java.net.InetAddress
+import scodec.bits.ByteVector
+import scala.util.Try
 
 case class Node(id: PublicKey, address: Node.Address)
 
@@ -11,4 +13,26 @@ object Node {
       udpPort: Int,
       tcpPort: Int
   )
+  object Address {
+    def fromEnr(enr: EthereumNodeRecord): Option[Node.Address] = {
+      import EthereumNodeRecord.Keys
+
+      def tryParse[T](key: ByteVector)(f: ByteVector => T): Option[T] =
+        enr.content.attrs.get(key).flatMap { value =>
+          Try(f(value)).toOption
+        }
+
+      def tryParseIP(key: ByteVector): Option[InetAddress] =
+        tryParse[InetAddress](key)(bytes => InetAddress.getByAddress(bytes.toArray))
+
+      def tryParsePort(key: ByteVector): Option[Int] =
+        tryParse[Int](key)(_.toInt())
+
+      for {
+        ip <- tryParseIP(Keys.ip6) orElse tryParseIP(Keys.ip)
+        udp <- tryParsePort(Keys.udp6) orElse tryParsePort(Keys.udp)
+        tcp <- tryParsePort(Keys.tcp6) orElse tryParsePort(Keys.tcp)
+      } yield Node.Address(ip, udpPort = udp, tcpPort = tcp)
+    }
+  }
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
@@ -1,13 +1,24 @@
 package io.iohk.scalanet.discovery.ethereum
 
 import io.iohk.scalanet.discovery.crypto.PublicKey
+import io.iohk.scalanet.discovery.hash.{Hash, Keccak256}
 import java.net.InetAddress
 import scodec.bits.ByteVector
 import scala.util.Try
 
-case class Node(id: PublicKey, address: Node.Address)
+case class Node(id: Node.Id, address: Node.Address) {
+  protected[discovery] lazy val kademliaId: Hash = Node.kademliaId(id)
+}
 
 object Node {
+
+  /** 64 bit uncompressed Secp256k1 public key. */
+  type Id = PublicKey
+
+  /** The ID of the node is the 64 bit public key, but for the XOR distance we use its hash. */
+  protected[discovery] def kademliaId(id: PublicKey): Hash =
+    Keccak256(id)
+
   case class Address(
       ip: InetAddress,
       udpPort: Int,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/codecs/DefaultCodecs.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/codecs/DefaultCodecs.scala
@@ -44,6 +44,9 @@ object DefaultCodecs {
   implicit val attrCodec: Codec[SortedMap[ByteVector, ByteVector]] =
     sortedMapCodec[ByteVector, ByteVector]
 
+  implicit val enrContentCodec: Codec[EthereumNodeRecord.Content] =
+    Codec.deriveLabelledGeneric
+
   implicit val enrCodec: Codec[EthereumNodeRecord] =
     Codec.deriveLabelledGeneric
 

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
@@ -15,6 +15,8 @@ case class DiscoveryConfig(
     kademliaTimeout: FiniteDuration,
     // Max number of neighbours to expect.
     kademliaBucketSize: Int,
+    // Concurrencly parameter 'alpha' for recursive Kademlia lookups.
+    kademliaAlpha: Int,
     // Maximum time we consider a peer bonded without receiving a Pong response to a Ping.
     bondExpiration: FiniteDuration,
     // How often to look for new peers.
@@ -28,6 +30,7 @@ object DiscoveryConfig {
     requestTimeout = 3.seconds,
     kademliaTimeout = 7.seconds,
     kademliaBucketSize = 16,
+    kademliaAlpha = 3,
     bondExpiration = 12.hours,
     discoveryPeriod = 15.minutes
   )

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
@@ -14,7 +14,9 @@ case class DiscoveryConfig(
     // Timeout for collecting multiple potential Neighbors responses.
     kademliaTimeout: FiniteDuration,
     // Max number of neighbours to expect.
-    kademliaBucketSize: Int
+    kademliaBucketSize: Int,
+    // Maximum time we consider a peer bonded without receiving a Pong response to a Ping.
+    bondExpiration: FiniteDuration
 )
 
 object DiscoveryConfig {
@@ -23,6 +25,7 @@ object DiscoveryConfig {
     maxClockDrift = Duration.Zero,
     requestTimeout = 3.seconds,
     kademliaTimeout = 7.seconds,
-    kademliaBucketSize = 16
+    kademliaBucketSize = 16,
+    bondExpiration = 12.hours
   )
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
@@ -16,7 +16,9 @@ case class DiscoveryConfig(
     // Max number of neighbours to expect.
     kademliaBucketSize: Int,
     // Maximum time we consider a peer bonded without receiving a Pong response to a Ping.
-    bondExpiration: FiniteDuration
+    bondExpiration: FiniteDuration,
+    // How often to look for new peers.
+    discoveryPeriod: FiniteDuration
 )
 
 object DiscoveryConfig {
@@ -26,6 +28,7 @@ object DiscoveryConfig {
     requestTimeout = 3.seconds,
     kademliaTimeout = 7.seconds,
     kademliaBucketSize = 16,
-    bondExpiration = 12.hours
+    bondExpiration = 12.hours,
+    discoveryPeriod = 15.minutes
   )
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryConfig.scala
@@ -1,5 +1,6 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
+import io.iohk.scalanet.discovery.ethereum.Node
 import scala.concurrent.duration._
 
 case class DiscoveryConfig(
@@ -20,7 +21,9 @@ case class DiscoveryConfig(
     // Maximum time we consider a peer bonded without receiving a Pong response to a Ping.
     bondExpiration: FiniteDuration,
     // How often to look for new peers.
-    discoveryPeriod: FiniteDuration
+    discoveryPeriod: FiniteDuration,
+    // Bootstrap nodes.
+    knownPeers: Set[Node]
 )
 
 object DiscoveryConfig {
@@ -32,6 +35,7 @@ object DiscoveryConfig {
     kademliaBucketSize = 16,
     kademliaAlpha = 3,
     bondExpiration = 12.hours,
-    discoveryPeriod = 15.minutes
+    discoveryPeriod = 15.minutes,
+    knownPeers = Set.empty
   )
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -39,9 +39,11 @@ object DiscoveryNetwork {
     * We have to use the pair for addressing a peer as well to set an expectation of the identity we
     * expect to talk to, i.e. who should sign the packets.
     */
-  case class Peer[A](id: PublicKey, address: A) {
+  case class Peer[A](id: Node.Id, address: A) {
     override def toString: String =
       s"Peer(id = ${id.toHex}, address = $address)"
+
+    lazy val kademliaId: Hash = Node.kademliaId(id)
   }
 
   // Errors that stop the processing of incoming messages on a channel.

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -52,6 +52,8 @@ object DiscoveryNetwork {
   def apply[A](
       peerGroup: PeerGroup[A, Packet],
       privateKey: PrivateKey,
+      // Sent in pings; some clients use the the TCP port in the `from` so it should be accurate.
+      localNodeAddress: Node.Address,
       toNodeAddress: A => Node.Address,
       config: DiscoveryConfig
   )(implicit codec: Codec[Payload], sigalg: SigAlg, clock: Clock[Task]): Task[DiscoveryNetwork[A]] = Task {
@@ -65,9 +67,6 @@ object DiscoveryNetwork {
       private val currentTimeMillis = clock.realTime(MILLISECONDS)
 
       private val maxNeighborsPerPacket = getMaxNeighborsPerPacket
-
-      // This is only sent in Ping packets and is basically ignored by nodes.
-      private val localNodeAddress = toNodeAddress(peerGroup.processAddress)
 
       /** Start a fiber that accepts incoming channels and starts a dedicated fiber
         * to handle every channel separtely, processing their messages one by one.

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -39,7 +39,10 @@ object DiscoveryNetwork {
     * We have to use the pair for addressing a peer as well to set an expectation of the identity we
     * expect to talk to, i.e. who should sign the packets.
     */
-  case class Peer[A](id: PublicKey, address: A)
+  case class Peer[A](id: PublicKey, address: A) {
+    override def toString: String =
+      s"Peer(id = ${id.toHex}, address = $address)"
+  }
 
   // Errors that stop the processing of incoming messages on a channel.
   class PacketException(message: String) extends Exception(message) with NoStackTrace

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -204,10 +204,8 @@ object DiscoveryService {
             } yield closestNodes
           }
 
-    override def enrRequest: Call[Peer[A], Proc.ENRRequest] = ???
-
-    private def ifBonded[T](caller: Peer[A])(thunk: Task[T]): Task[Option[T]] =
-      isBonded(caller).ifM(thunk.map(Some(_)), Task.pure(None))
+    override def enrRequest: Call[Peer[A], Proc.ENRRequest] =
+      caller => _ => ifBonded(caller)(stateRef.get.map(_.enr))
 
     def enroll(): Task[Unit] = ???
 
@@ -241,6 +239,9 @@ object DiscoveryService {
         }
       }
     }
+
+    protected[v4] def ifBonded[T](caller: Peer[A])(thunk: Task[T]): Task[Option[T]] =
+      isBonded(caller).ifM(thunk.map(Some(_)), Task.pure(None))
 
     /** Runs the bonding process with the peer, unless already bonded.
       *

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -41,7 +41,7 @@ trait DiscoveryService {
   def updateExternalAddress(address: InetAddress): Task[Unit]
 
   /** The local node representation. */
-  def localNode: Task[Node]
+  def getLocalNode: Task[Node]
 }
 
 object DiscoveryService {
@@ -194,12 +194,14 @@ object DiscoveryService {
       with DiscoveryRPC[Peer[A]]
       with LazyLogging {
 
+    override def getLocalNode: Task[Node] =
+      stateRef.get.map(_.node)
+
     override def getNode(nodeId: NodeId): Task[Option[Node]] = ???
     override def getNodes: Task[Set[Node]] = ???
     override def addNode(node: Node): Task[Unit] = ???
     override def removeNode(nodeId: NodeId): Task[Unit] = ???
     override def updateExternalAddress(address: InetAddress): Task[Unit] = ???
-    override def localNode: Task[Node] = ???
 
     /** Handle incoming Ping request. */
     override def ping: Call[Peer[A], Proc.Ping] =

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -225,7 +225,7 @@ object DiscoveryService {
       bondExpiration: FiniteDuration,
       // How long to wait for the remote peer to send a ping to us.
       requestTimeout: FiniteDuration
-  )(implicit sr: StateRef[A], clock: Clock[Task]): Task[Boolean] = {
+  )(implicit sr: StateRef[A], clock: Clock[Task]): Task[Boolean] =
     isBonded(bondExpiration, peer).flatMap {
       case true =>
         Task.pure(true)
@@ -250,7 +250,6 @@ object DiscoveryService {
               }
         }
     }
-  }
 
   /** Check and modify the bonding state of the peer: if we're already bonding
     * return the Deferred result we can wait on, otherwise add a new Deferred

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -1,9 +1,134 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
-/** Implement the stateful discovery logic:
-  * - maintain the state of K-buckets
-  * - return node candidates for the rest of the system
-  * - bond with the other nodes
-  * - respond to incoming requests
+import cats.effect.{Resource, Fiber}
+import cats.effect.concurrent.{Deferred, Ref}
+import io.iohk.scalanet.discovery.crypto.{PublicKey}
+import io.iohk.scalanet.discovery.ethereum.{Node, EthereumNodeRecord}
+import io.iohk.scalanet.kademlia.KBuckets
+import monix.eval.Task
+import monix.catnap.CancelableF
+import java.net.InetAddress
+
+/** Represent the minimal set of operations the rest of the system
+  * can expect from the service to be able to talk to other peers.
   */
-trait DiscoveryService[A] {}
+trait DiscoveryService {
+  import DiscoveryService.NodeId
+
+  /** Try to look up a node either in the local cache or
+    * by performing a recursive lookup on the network. */
+  def getNode(nodeId: NodeId): Task[Option[Node]]
+
+  /** Return all currently bonded nodes. */
+  def getNodes: Task[Set[Node]]
+
+  /** Add a node to the local cache and try to bond with it. */
+  def addNode(node: Node): Task[Unit]
+
+  /** Remove a node from the local cache. */
+  def removeNode(nodeId: NodeId): Task[Unit]
+
+  /** Update the local node with an updated external address,
+    * incrementing the local ENR sequence.
+    */
+  def updateExternalAddress(address: InetAddress): Task[Unit]
+
+  /** The local node representation. */
+  def localNode: Task[Node]
+}
+
+object DiscoveryService {
+  type NodeId = PublicKey
+  import DiscoveryRPC.{Call, Proc}
+
+  /** Implement the Discovery v4 protocol:
+    *
+    * https://github.com/ethereum/devp2p/blob/master/discv4.md
+    *
+    * - maintain the state of K-buckets
+    * - return node candidates for the rest of the system
+    * - bond with the other nodes
+    * - respond to incoming requests
+    * - periodically try to discover new nodes
+    * - periodically ping nodes
+    */
+  def apply[A](
+      node: Node,
+      enr: EthereumNodeRecord,
+      network: DiscoveryNetwork[A]
+  ): Resource[Task, DiscoveryService] =
+    Resource
+      .make {
+        for {
+          stateRef <- Ref[Task].of(State(node, enr))
+          service <- Task(new DiscoveryServiceImpl[A](network, stateRef))
+          cancelToken <- service.startRequestHandling()
+          _ <- service.enroll()
+          refreshFiber <- service.startPeriodicRefresh()
+          discoveryFiber <- service.startPeriodicDiscovery()
+        } yield (service, cancelToken, refreshFiber, discoveryFiber)
+      } {
+        case (_, cancelToken, refreshFiber, discoveryFiber) =>
+          cancelToken.cancel >> refreshFiber.cancel >> discoveryFiber.cancel
+      }
+      .map(_._1)
+
+  case class State(
+      // Kademlia buckets with node IDs in them.
+      kBuckets: KBuckets,
+      nodeMap: Map[NodeId, Node],
+      enrMap: Map[NodeId, EthereumNodeRecord],
+      bondStateMap: Map[NodeId, BondingState]
+  )
+  object State {
+    def apply(
+        node: Node,
+        enr: EthereumNodeRecord,
+        clock: java.time.Clock = java.time.Clock.systemUTC()
+    ): State = State(
+      kBuckets = new KBuckets(node.id, clock),
+      nodeMap = Map(node.id -> node),
+      enrMap = Map(node.id -> enr),
+      bondStateMap = Map.empty
+    )
+  }
+
+  sealed trait BondingState
+  object BondingState {
+
+    /** Bonding has already been initiated, the Deferred will be completed with the
+      * the eventual result which is `true` if the peer responded or `false` if it didn't. */
+    case class Pinging(result: Deferred[Task, Boolean]) extends BondingState
+
+    /** Responded to a Ping with a Pong at the given timestamp. */
+    case class Succeeded(timestamp: Long) extends BondingState
+
+    /** Did not respond to Ping the last time it was attempted. */
+    case class Failed(timestamp: Long) extends BondingState
+  }
+
+  class DiscoveryServiceImpl[A](
+      network: DiscoveryNetwork[A],
+      stateRef: Ref[Task, State]
+  ) extends DiscoveryService
+      with DiscoveryRPC[(PublicKey, A)] {
+
+    override def getNode(nodeId: NodeId): Task[Option[Node]] = ???
+    override def getNodes: Task[Set[Node]] = ???
+    override def addNode(node: Node): Task[Unit] = ???
+    override def removeNode(nodeId: NodeId): Task[Unit] = ???
+    override def updateExternalAddress(address: InetAddress): Task[Unit] = ???
+    override def localNode: Task[Node] = ???
+    override def ping: Call[(PublicKey, A), Proc.Ping] = ???
+    override def findNode: Call[(PublicKey, A), Proc.FindNode] = ???
+    override def enrRequest: Call[(PublicKey, A), Proc.ENRRequest] = ???
+
+    def enroll(): Task[Unit] = ???
+    def startRequestHandling(): Task[CancelableF[Task]] = ???
+    def startPeriodicRefresh(): Task[Fiber[Task, Unit]] = ???
+    def startPeriodicDiscovery(): Task[Fiber[Task, Unit]] = ???
+
+    def bond(): Task[Boolean] = ???
+    def lookup(nodeId: NodeId): Task[Option[Node]] = ???
+  }
+}

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -151,6 +151,8 @@ object DiscoveryService {
       extends DiscoveryService
       with DiscoveryRPC[Peer[A]] {
 
+    // Passing the state to the pure functions that live on the
+    // companion object, to make them easily testable.
     implicit val sr = stateRef
 
     override def getNode(nodeId: NodeId): Task[Option[Node]] = ???
@@ -164,7 +166,7 @@ object DiscoveryService {
       caller =>
         maybeRemoteEnrSeq =>
           for {
-            _ <- completePing(caller)
+            _ <- DiscoveryService.completePing(caller)
             enr <- stateRef.get.map(_.enr.content.seq)
             // TODO: Check if the ENR is fresher than what we have and maybe fetch again.
           } yield Some(Some(enr))

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -42,17 +42,12 @@ trait DiscoveryService {
 
 object DiscoveryService {
   import DiscoveryRPC.{Call, Proc}
+  import DiscoveryNetwork.Peer
 
   type ENRSeq = Long
   type Timestamp = Long
   type NodeId = PublicKey
   type StateRef[A] = Ref[Task, State[A]]
-
-  type Peer[A] = (NodeId, A)
-  private implicit class PeerOps[A](peer: Peer[A]) {
-    def id: NodeId = peer._1
-    def address: A = peer._2
-  }
 
   /** Implement the Discovery v4 protocol:
     *
@@ -221,7 +216,7 @@ object DiscoveryService {
     */
   protected[v4] def bond[A](
       peer: Peer[A],
-      rpc: DiscoveryRPC[A],
+      rpc: DiscoveryRPC[Peer[A]],
       bondExpiration: FiniteDuration,
       // How long to wait for the remote peer to send a ping to us.
       requestTimeout: FiniteDuration
@@ -237,7 +232,7 @@ object DiscoveryService {
 
           case Right(enrSeq) =>
             rpc
-              .ping(peer.address)(Some(enrSeq))
+              .ping(peer)(Some(enrSeq))
               .recover {
                 case NonFatal(_) => None
               }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -86,7 +86,6 @@ object DiscoveryService {
           _ <- service.enroll(bootstraps).whenA(bootstraps.nonEmpty)
           // Periodically discover new nodes.
           discoveryFiber <- service.lookupRandom().delayExecution(config.discoveryPeriod).loopForever.start
-          // TODO: Periodically ping peers before they become unbonded.
         } yield (service, cancelToken, discoveryFiber)
       } {
         case (_, cancelToken, discoveryFiber) =>

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -786,9 +786,9 @@ object DiscoveryService {
 
         tryEnroll.flatTap {
           case true =>
-            Task(logger.info("Successfully enrolled with the bootstrap nodes."))
+            Task(logger.info("Successfully enrolled with some of the bootstrap nodes."))
           case false =>
-            Task(logger.warn("Failed to enroll with the bootstrap nodes."))
+            Task(logger.warn("Failed to enroll with any of the the bootstrap nodes."))
         }
       }
   }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -569,7 +569,9 @@ object DiscoveryService {
       }
     }
 
-    protected[v4] def lookupRandom(): Task[Unit] = ???
+    /** Look up a random node ID to discovery new peers. */
+    protected[v4] def lookupRandom(): Task[Unit] =
+      lookup(target = sigalg.newKeyPair._1).void
 
     /** Look up self with the bootstrap nodes. That should involve bonding with the bootstraps.
       * Raise an error if in the end we failed to get the ENR from any node as that would mean

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -49,7 +49,7 @@ object DiscoveryService {
   type StateRef[A] = Ref[Task, State[A]]
 
   type Peer[A] = (NodeId, A)
-  implicit class PeerOps[A](peer: Peer[A]) {
+  private implicit class PeerOps[A](peer: Peer[A]) {
     def id: NodeId = peer._1
     def address: A = peer._2
   }
@@ -88,13 +88,13 @@ object DiscoveryService {
       }
       .map(_._1)
 
-  case class BondingResults(
+  protected[v4] case class BondingResults(
       // Completed if the remote poor responds with a Pong during the bonding process.
       pongReceived: Deferred[Task, Boolean],
       // Completed if the remote peer pings us during the bonding process.
       pingReceived: Deferred[Task, Unit]
   )
-  object BondingResults {
+  protected[v4] object BondingResults {
     def apply(): Task[BondingResults] =
       for {
         pong <- Deferred[Task, Boolean]
@@ -105,7 +105,7 @@ object DiscoveryService {
       BondingResults(Deferred.unsafe[Task, Boolean], Deferred.unsafe[Task, Unit])
   }
 
-  case class State[A](
+  protected[v4] case class State[A](
       node: Node,
       enr: EthereumNodeRecord,
       // Kademlia buckets with node IDs in them.
@@ -126,7 +126,7 @@ object DiscoveryService {
     def clearBondingResults(peer: Peer[A]): State[A] =
       copy(bondingResultsMap = bondingResultsMap - peer)
   }
-  object State {
+  protected[v4] object State {
     def apply[A](
         node: Node,
         enr: EthereumNodeRecord,
@@ -142,7 +142,7 @@ object DiscoveryService {
     )
   }
 
-  class DiscoveryServiceImpl[A](
+  private class DiscoveryServiceImpl[A](
       network: DiscoveryNetwork[A],
       stateRef: StateRef[A],
       bondExpiration: FiniteDuration,
@@ -187,7 +187,7 @@ object DiscoveryService {
 
   }
 
-  private def currentTimeMillis(implicit clock: Clock[Task]): Task[Long] =
+  protected[v4] def currentTimeMillis(implicit clock: Clock[Task]): Task[Long] =
     clock.realTime(MILLISECONDS)
 
   /** Check if the given peer has a valid bond at the moment. */

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -384,7 +384,8 @@ object DiscoveryService {
     ): Task[Boolean] =
       isBonded(peer).flatMap {
         case true =>
-          Task.pure(true)
+          // Check that we have an ENR for this peer.
+          maybeFetchEnr(peer, maybeRemoteEnrSeq = None, delay = false).startAndForget.as(true)
 
         case false =>
           initBond(peer).flatMap {

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -367,7 +367,7 @@ object DiscoveryService {
     protected[v4] def respondIfBonded[T](caller: Peer[A], request: String)(response: Task[T]): Task[Option[T]] =
       isBonded(caller).flatMap {
         case true => response.map(Some(_))
-        case false => Task(logger.debug(s"Ignoring $request request from unbonded ${caller}")).as(None)
+        case false => Task(logger.debug(s"Ignoring $request request from unbonded $caller")).as(None)
       }
 
     /** Runs the bonding process with the peer, unless already bonded.
@@ -549,9 +549,9 @@ object DiscoveryService {
         case Right(fetch) =>
           val maybeEnr = bond(peer).flatMap {
             case false =>
-              Task(logger.debug(s"Could not bond with ${peer} to fetch ENR")).as(None)
+              Task(logger.debug(s"Could not bond with $peer to fetch ENR")).as(None)
             case true =>
-              Task(logger.debug(s"Fetching the ENR from ${peer}...")) >>
+              Task(logger.debug(s"Fetching the ENR from $peer...")) >>
                 rpc
                   .enrRequest(peer)(())
                   .delayExecution(if (delay) config.requestTimeout else Duration.Zero)
@@ -559,7 +559,7 @@ object DiscoveryService {
                     case None =>
                       // At this point we are still bonded with the peer, so they think they can send us requests.
                       // We just have to keep trying to get an ENR for them, until then we can't use them for routing.
-                      Task(logger.debug(s"Could not fetch ENR from ${peer}")).as(None)
+                      Task(logger.debug(s"Could not fetch ENR from $peer")).as(None)
 
                     case Some(enr) =>
                       EthereumNodeRecord.validateSignature(enr, publicKey = peer.id) match {
@@ -577,11 +577,11 @@ object DiscoveryService {
                           }
 
                         case Attempt.Successful(false) =>
-                          Task(logger.info(s"Could not validate ENR signature from ${peer}!")) >>
+                          Task(logger.info(s"Could not validate ENR signature from $peer!")) >>
                             removePeer(peer).as(None)
 
                         case Attempt.Failure(err) =>
-                          Task(logger.error(s"Error validateing ENR from ${peer}: $err")).as(None)
+                          Task(logger.error(s"Error validateing ENR from $peer: $err")).as(None)
                       }
                   }
           }
@@ -627,7 +627,7 @@ object DiscoveryService {
         }
         .flatMap {
           case None =>
-            Task(logger.debug(s"Added ${peer} to the k-buckets.")).as(Some(enr))
+            Task(logger.debug(s"Added $peer to the k-buckets.")).as(Some(enr))
 
           case Some(evictionCandidate) =>
             val evictionPeer = toPeer(evictionCandidate)
@@ -639,7 +639,7 @@ object DiscoveryService {
                 // lookups, but won't return the peer itself in results.
                 // A more sophisticated approach would be to put them in a separate replacement
                 // cache for the bucket where they can be drafted from if someone cannot bond again.
-                Task(logger.debug(s"Not adding ${peer} to the k-buckets, keeping ${evictionPeer}")) >>
+                Task(logger.debug(s"Not adding $peer to the k-buckets, keeping $evictionPeer")) >>
                   stateRef.update(_.withTouch(evictionPeer)).as(None)
 
               case false =>

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -200,8 +200,10 @@ object DiscoveryService {
     override def addNode(node: Node): Task[Unit] =
       maybeFetchEnr(toPeer(node), None)
 
+    override def getNodes: Task[Set[Node]] =
+      stateRef.get.map(_.nodeMap.values.toSet)
+
     override def getNode(nodeId: NodeId): Task[Option[Node]] = ???
-    override def getNodes: Task[Set[Node]] = ???
     override def removeNode(nodeId: NodeId): Task[Unit] = ???
     override def updateExternalAddress(address: InetAddress): Task[Unit] = ???
 

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -630,7 +630,7 @@ object DiscoveryService {
       */
     protected[v4] def lookup(target: NodeId): Task[SortedSet[Node]] = {
       implicit val nodeOrdering: Ordering[Node] =
-        XorOrdering[Node](target)(_.id)
+        XorOrdering[Node](_.id)(target)
 
       // Find the 16 closest nodes we know of.
       // We'll contact 'alpha' at a time but eventually try all of them

--- a/scalanet/discovery/src/io/iohk/scalanet/kademlia/KRouter.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/kademlia/KRouter.scala
@@ -164,7 +164,7 @@ class KRouter[A](
           toPing <- routerState.modify { current =>
             val (_, bucket) = current.kBuckets.getBucket(nodeRecord.id)
             if (bucket.contains(nodeRecord.id)) {
-              // The bucket is full but here we're handling a node we already have, perhaps as a side effect of an incoming request.
+              // We're handling a node we already have, perhaps as a side effect of an incoming request.
               // In this case it's enough to update the timestamp.
               (current.touchNodeRecord(nodeRecord), None)
             } else if (bucket.size < config.k) {
@@ -232,8 +232,8 @@ class KRouter[A](
         .map(id => state.nodeRecords(id))
     }.memoizeOnSuccess
 
-    implicit val xorOrder = new XorOrder[A](targetNodeId)
-    implicit val xorOrdering = xorOrder.xorNodeOrder
+    implicit val xorNodeOrder = new XorNodeOrder[A](targetNodeId)
+    implicit val xorNodeOrdering = xorNodeOrder.xorNodeOrdering
 
     def query(knownNodeRecord: NodeRecord[A]): Task[Seq[NodeRecord[A]]] = {
 
@@ -300,7 +300,7 @@ class KRouter[A](
     ): Task[Seq[NodeRecord[A]]] = {
 
       // All nodes which are closer to target, than the closest already found node
-      val closestNodes = receivedNodes.filter(node => xorOrder.compare(node, currentClosestNode) < 0)
+      val closestNodes = receivedNodes.filter(node => xorNodeOrder.compare(node, currentClosestNode) < 0)
 
       // we chose either:
       // k nodes from already found or

--- a/scalanet/discovery/src/io/iohk/scalanet/kademlia/KRouter.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/kademlia/KRouter.scala
@@ -139,7 +139,7 @@ class KRouter[A](
     routerState.update(current => current.removeNodeRecord(current.nodeRecords(nodeId)))
   }
 
-  def kBuckets: Task[KBuckets] = {
+  def kBuckets: Task[KBuckets[BitVector]] = {
     routerState.get.map(_.kBuckets)
   }
 
@@ -444,7 +444,10 @@ object KRouter {
   )
 
   private[scalanet] def getIndex[A](config: Config[A], clock: Clock): NodeRecordIndex[A] = {
-    NodeRecordIndex(new KBuckets(config.nodeRecord.id, clock), Map(config.nodeRecord.id -> config.nodeRecord))
+    NodeRecordIndex(
+      new KBuckets[BitVector](config.nodeRecord.id, clock),
+      Map(config.nodeRecord.id -> config.nodeRecord)
+    )
   }
 
   /**
@@ -551,7 +554,7 @@ object KRouter {
 
     }
 
-    case class NodeRecordIndex[A](kBuckets: KBuckets, nodeRecords: Map[BitVector, NodeRecord[A]]) {
+    case class NodeRecordIndex[A](kBuckets: KBuckets[BitVector], nodeRecords: Map[BitVector, NodeRecord[A]]) {
       def addNodeRecord(nodeRecord: NodeRecord[A]): NodeRecordIndex[A] = {
         copy(kBuckets = kBuckets.add(nodeRecord.id), nodeRecords = nodeRecords + (nodeRecord.id -> nodeRecord))
       }

--- a/scalanet/discovery/src/io/iohk/scalanet/kademlia/XorOrdering.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/kademlia/XorOrdering.scala
@@ -28,7 +28,7 @@ object XorOrdering {
   // distance, but in pathological tests it's not intuitive that sets of
   // different nodes with the same ID but different attributes disappear
   // from the set.
-  def apply[T](base: BitVector)(f: T => BitVector): Ordering[T] = {
+  def apply[T](f: T => BitVector)(base: BitVector): Ordering[T] = {
     val xorOrdering = new XorOrdering(base)
     val tupleOrdering = Ordering.Tuple2(xorOrdering, Ordering.Int)
     Ordering.by[T, (BitVector, Int)] { x =>
@@ -39,7 +39,7 @@ object XorOrdering {
 
 object XorNodeOrdering {
   def apply[A](base: BitVector): Ordering[NodeRecord[A]] =
-    XorOrdering[NodeRecord[A]](base)(_.id)
+    XorOrdering[NodeRecord[A]](_.id)(base)
 }
 
 class XorNodeOrder[A](val base: BitVector) extends Order[NodeRecord[A]] {

--- a/scalanet/discovery/test/resources/logback-test.xml
+++ b/scalanet/discovery/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%t %0logger %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="OFF"/>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/scalanet/discovery/test/resources/logback-test.xml
+++ b/scalanet/discovery/test/resources/logback-test.xml
@@ -9,6 +9,7 @@
 
     <logger name="io.netty" level="OFF"/>
 
+    <!-- Don't want to see all the logs induced by unit tests. -->
     <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/scalanet/discovery/test/resources/logback-test.xml
+++ b/scalanet/discovery/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
 
     <logger name="io.netty" level="OFF"/>
 
-    <!-- Don't want to see all the logs induced by unit tests. -->
+    <!-- Don't want to see all the logs induced by unit tests, but can be enabled to fix failing tests. -->
     <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
@@ -3,7 +3,6 @@ package io.iohk.scalanet.discovery.ethereum
 import io.iohk.scalanet.NetUtils.aRandomAddress
 import io.iohk.scalanet.discovery.ethereum.codecs.DefaultCodecs
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
-import io.iohk.scalanet.discovery.ethereum.v4.DiscoveryNetworkSpec.randomKeyPair
 import org.scalatest._
 
 class EthereumNodeRecordSpec extends FlatSpec with Matchers {
@@ -13,7 +12,7 @@ class EthereumNodeRecordSpec extends FlatSpec with Matchers {
   behavior of "fromNode"
 
   it should "survive a roundtrip" in {
-    val (publicKey, privateKey) = randomKeyPair
+    val (publicKey, privateKey) = sigalg.newKeyPair
     val address = aRandomAddress
     val node = Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
 

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
@@ -1,0 +1,25 @@
+package io.iohk.scalanet.discovery.ethereum
+
+import io.iohk.scalanet.NetUtils.aRandomAddress
+import io.iohk.scalanet.discovery.ethereum.codecs.DefaultCodecs
+import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
+import io.iohk.scalanet.discovery.ethereum.v4.DiscoveryNetworkSpec.randomKeyPair
+import org.scalatest._
+
+class EthereumNodeRecordSpec extends FlatSpec with Matchers {
+  import DefaultCodecs._
+  implicit val sigalg = new MockSigAlg()
+
+  behavior of "fromNode"
+
+  it should "survive a roundtrip" in {
+    val (publicKey, privateKey) = randomKeyPair
+    val address = aRandomAddress
+    val node = Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
+
+    val enr = EthereumNodeRecord.fromNode(node, privateKey, seq = 1).require
+    val nodeAddress = Node.Address.fromEnr(enr)
+
+    nodeAddress shouldBe Some(node.address)
+  }
+}

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecordSpec.scala
@@ -1,24 +1,48 @@
 package io.iohk.scalanet.discovery.ethereum
 
-import io.iohk.scalanet.NetUtils.aRandomAddress
 import io.iohk.scalanet.discovery.ethereum.codecs.DefaultCodecs
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
+import java.net.InetAddress
 import org.scalatest._
 
 class EthereumNodeRecordSpec extends FlatSpec with Matchers {
   import DefaultCodecs._
+  import EthereumNodeRecord.Keys
+
   implicit val sigalg = new MockSigAlg()
+  val (publicKey, privateKey) = sigalg.newKeyPair
 
   behavior of "fromNode"
 
-  it should "survive a roundtrip" in {
-    val (publicKey, privateKey) = sigalg.newKeyPair
-    val address = aRandomAddress
-    val node = Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
+  it should "use the right keys for IPv6 addresses" in {
+    val addr = InetAddress.getByName("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+    val node = Node(publicKey, Node.Address(addr, 30000, 40000))
 
     val enr = EthereumNodeRecord.fromNode(node, privateKey, seq = 1).require
-    val nodeAddress = Node.Address.fromEnr(enr)
+    Inspectors.forAll(List(Keys.ip6, Keys.tcp6, Keys.udp6)) { k =>
+      enr.content.attrs should contain key (k)
+    }
+    Inspectors.forAll(List(Keys.ip, Keys.tcp, Keys.udp)) { k =>
+      enr.content.attrs should not contain key(k)
+    }
 
+    val nodeAddress = Node.Address.fromEnr(enr)
+    nodeAddress shouldBe Some(node.address)
+  }
+
+  it should "use the right keys for IPv4 addresses" in {
+    val addr = InetAddress.getByName("127.0.0.1")
+    val node = Node(publicKey, Node.Address(addr, 31000, 42000))
+
+    val enr = EthereumNodeRecord.fromNode(node, privateKey, seq = 2).require
+    Inspectors.forAll(List(Keys.ip6, Keys.tcp6, Keys.udp6)) { k =>
+      enr.content.attrs should not contain key(k)
+    }
+    Inspectors.forAll(List(Keys.ip, Keys.tcp, Keys.udp)) { k =>
+      enr.content.attrs should contain key (k)
+    }
+
+    val nodeAddress = Node.Address.fromEnr(enr)
     nodeAddress shouldBe Some(node.address)
   }
 }

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
@@ -837,6 +837,7 @@ object DiscoveryNetworkSpec extends Matchers {
       DiscoveryNetwork[InetSocketAddress](
         peerGroup = peerGroup,
         privateKey = privateKey,
+        localNodeAddress = toNodeAddress(localAddress),
         toNodeAddress = toNodeAddress,
         config = config
       ).runSyncUnsafe()

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
@@ -808,12 +808,14 @@ object DiscoveryNetworkSpec extends Matchers {
     lazy val (publicKey, privateKey) = randomKeyPair
 
     lazy val localENR = EthereumNodeRecord(
-      seq = 456L,
       signature = Signature(BitVector(randomBytes(65))),
-      attrs = SortedMap(
-        EthereumNodeRecord.Keys.id -> ByteVector("v4".getBytes),
-        EthereumNodeRecord.Keys.ip -> ByteVector(localAddress.getAddress.getAddress),
-        EthereumNodeRecord.Keys.udp -> ByteVector(localAddress.getPort)
+      content = EthereumNodeRecord.Content(
+        seq = 456L,
+        attrs = SortedMap(
+          EthereumNodeRecord.Keys.id -> ByteVector("v4".getBytes),
+          EthereumNodeRecord.Keys.ip -> ByteVector(localAddress.getAddress.getAddress),
+          EthereumNodeRecord.Keys.udp -> ByteVector(localAddress.getPort)
+        )
       )
     )
 
@@ -823,12 +825,14 @@ object DiscoveryNetworkSpec extends Matchers {
     lazy val remotePeer = Peer(remotePublicKey, remoteAddress)
 
     lazy val remoteENR = EthereumNodeRecord(
-      seq = 123L,
       signature = Signature(BitVector(randomBytes(65))),
-      attrs = SortedMap(
-        EthereumNodeRecord.Keys.id -> ByteVector("v4".getBytes),
-        EthereumNodeRecord.Keys.ip -> ByteVector(remoteAddress.getAddress.getAddress),
-        EthereumNodeRecord.Keys.udp -> ByteVector(remoteAddress.getPort)
+      content = EthereumNodeRecord.Content(
+        seq = 123L,
+        attrs = SortedMap(
+          EthereumNodeRecord.Keys.id -> ByteVector("v4".getBytes),
+          EthereumNodeRecord.Keys.ip -> ByteVector(remoteAddress.getAddress.getAddress),
+          EthereumNodeRecord.Keys.udp -> ByteVector(remoteAddress.getPort)
+        )
       )
     )
 

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
@@ -789,7 +789,7 @@ object DiscoveryNetworkSpec extends Matchers {
       tcpPort = address.getPort
     )
 
-  val defaultConfig = DiscoveryConfig(
+  val defaultConfig = DiscoveryConfig.default.copy(
     requestTimeout = 100.millis,
     messageExpiration = 60.seconds,
     kademliaTimeout = 250.millis,

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -1,6 +1,6 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
-import cats.effect.concurrent.{Ref, Deferred}
+import cats.effect.concurrent.Ref
 import io.iohk.scalanet.discovery.ethereum.{EthereumNodeRecord, Node}
 import io.iohk.scalanet.discovery.ethereum.codecs.DefaultCodecs
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
@@ -14,7 +14,7 @@ import io.iohk.scalanet.discovery.crypto.PublicKey
 
 class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
   import DiscoveryServiceSpec._
-  import DiscoveryService.State
+  import DiscoveryService.{State, BondingResults}
 
   def test(fixture: Fixture) =
     fixture.test.runToFuture
@@ -66,7 +66,7 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
       override def peer = remotePeer
       override def expected = true
       override def setupState =
-        _.withPingingResult(remotePeer, Deferred.unsafe[Task, Boolean])
+        _.withBondingResults(remotePeer, BondingResults.unsafe())
           .withLastPongTimestamp(remotePeer, System.currentTimeMillis - bondExpiration.toMillis + 1000)
     }
   }
@@ -75,7 +75,7 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
       override def peer = remotePeer
       override def expected = false
       override def setupState =
-        _.withPingingResult(remotePeer, Deferred.unsafe[Task, Boolean])
+        _.withBondingResults(remotePeer, BondingResults.unsafe())
           .withLastPongTimestamp(remotePeer, System.currentTimeMillis - bondExpiration.toMillis - 1000)
     }
   }
@@ -98,6 +98,14 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
 
   behavior of "completeBond"
   it should "complete all bonds initiated to the peer" in (pending)
+
+  behavior of "awaitPing"
+  it should "wait up to the request timeout if there's no ping" in (pending)
+  it should "complete as soon as there's a ping" in (pending)
+
+  behavior of "completePing"
+  it should "complete the expected ping" in (pending)
+  it should "ignore subsequent pings" in (pending)
 
   behavior of "bond"
   it should "not try to bond if already bonded" in (pending)

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -746,8 +746,12 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
     new LookupFixture {
       override val expectedTarget = Some(localNode.id)
 
+      override lazy val config = defaultConfig.copy(
+        knownPeers = Set(remoteNode)
+      )
+
       override val test = for {
-        enrolled <- service.enroll(Set(remoteNode))
+        enrolled <- service.enroll()
         state <- stateRef.get
       } yield {
         enrolled shouldBe true
@@ -762,8 +766,13 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
         ping = _ => _ => Task.pure(Some(None)),
         enrRequest = _ => _ => Task.pure(None)
       )
+
+      override lazy val config = defaultConfig.copy(
+        knownPeers = Set(remoteNode)
+      )
+
       override val test = for {
-        enrolled <- service.enroll(Set(remoteNode))
+        enrolled <- service.enroll()
         state <- stateRef.get
       } yield {
         enrolled shouldBe false

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -732,11 +732,26 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "lookup a node remotely if not found locally" in (pending)
 
   behavior of "getNodes"
-  it should "not return the local node" in (pending)
-  it should "not return nodes which aren't bonded" in (pending)
-  it should "return bonded nodes" in (pending)
+
+  it should "return the local node among all nodes which have an ENR" in test {
+    new LookupFixture {
+      override val test = for {
+        nodes0 <- service.getNodes
+        _ <- addRemotePeer
+        nodes1 <- service.getNodes
+        _ <- service.lookup(targetPublicKey)
+        nodes2 <- service.getNodes
+        state <- stateRef.get
+      } yield {
+        nodes0 shouldBe Set(localNode)
+        nodes1 shouldBe Set(localNode, remoteNode)
+        nodes2.size shouldBe state.enrMap.size
+      }
+    }
+  }
 
   behavior of "addNode"
+
   it should "try to fetch the ENR of the node" in test {
     new Fixture {
       override lazy val rpc = unimplementedRPC.copy(

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -2,7 +2,70 @@ package io.iohk.scalanet.discovery.ethereum.v4
 
 import org.scalatest._
 
-class DiscoveryServiceSpec extends FlatSpec {
+trait DiscoveryServiceSpec extends FlatSpec {
 
-  behavior of "DiscoveryService"
+  behavior of "getNode"
+  it should "return the local node" in (pending)
+  it should "not return a nodes which is not bonded" in (pending)
+  it should "return a bonded node" in (pending)
+  it should "return a node from the local cache" in (pending)
+  it should "lookup a node remotely if not found locally" in (pending)
+
+  behavior of "getNodes"
+  it should "not return the local node" in (pending)
+  it should "not return nodes which aren't bonded" in (pending)
+  it should "return bonded nodes" in (pending)
+
+  behavior of "addNode"
+  it should "try to bond with the node" in (pending)
+
+  behavior of "removeNode"
+  it should "remove bonded or unbonded nodes from the cache" in (pending)
+
+  behavior of "updateExternalAddress"
+  it should "update the address of the local node" in (pending)
+  it should "increment the local ENR sequence" in (pending)
+
+  behavior of "localNode"
+  it should "return the latest local node record" in (pending)
+
+  behavior of "enroll"
+  it should "perform a self-lookup with the bootstrap nodes" in (pending)
+
+  behavior of "startPeriodicRefresh"
+  it should "periodically ping nodes" in (pending)
+
+  behavior of "startPeriodicDiscovery"
+  it should "periodically lookup a random node" in (pending)
+
+  behavior of "startRequestHandling"
+  it should "respond to pings with its local ENR sequence" in (pending)
+  it should "not respond to findNode from unbonded peers" in (pending)
+  it should "respond to findNode from bonded peer with the closest bonded peers" in (pending)
+  it should "not respond to enrRequest from unbonded peers" in (pending)
+  it should "respond to enrRequest from bonded peers with its signed local ENR" in (pending)
+  it should "bond with peers that ping it" in (pending)
+  it should "update the node record to the latest it connected from" in (pending)
+
+  behavior of "initBond"
+  it should "try to bond if past the expiration period" in (pending)
+  it should "not try to bond again within the expiration period" in (pending)
+  it should "only do one bond with a given peer at a time" in (pending)
+
+  behavior of "completeBond"
+  it should "complete all bonds initiated to the peer" in (pending)
+
+  behavior of "bond"
+  it should "not try to bond if already bonded" in (pending)
+  it should "fetch the ENR once bonded" in (pending)
+  it should "remove nodes if the bonding fails" in (pending)
+  it should "wait for a ping to arrive from the other party" in (pending)
+
+  behavior of "lookup"
+  it should "bond with nodes while doing recursive lookups before contacting them" in (pending)
+  it should "return the node seeked or nothing" in (pending)
+  it should "fetch the ENR record of the node" in (pending)
+
+  behavior of "fetchEnr"
+  it should "validate that the packet sender signed the ENR" in (pending)
 }

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -578,6 +578,18 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
     }
   }
 
+  behavior of "lookup"
+  it should "bond with nodes while doing recursive lookups while contacting them" in (pending)
+  it should "return the k closest nodes to the target" in (pending)
+  it should "fetch the ENR records of the nodes encountered" in (pending)
+
+  behavior of "lookupRandom"
+  it should "lookup a random node" in (pending)
+
+  behavior of "enroll"
+  it should "perform a self-lookup with the bootstrap nodes" in (pending)
+  it should "fail if it cannot retrieve any ENRs" in (pending)
+
   behavior of "getNode"
   it should "return the local node" in (pending)
   it should "not return a nodes which is not bonded" in (pending)
@@ -602,17 +614,6 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
 
   behavior of "localNode"
   it should "return the latest local node record" in (pending)
-
-  behavior of "enroll"
-  it should "perform a self-lookup with the bootstrap nodes" in (pending)
-
-  behavior of "lookupRandom"
-  it should "lookup a random node" in (pending)
-
-  behavior of "lookup"
-  it should "bond with nodes while doing recursive lookups before contacting them" in (pending)
-  it should "return the node seeked or nothing" in (pending)
-  it should "fetch the ENR record of the node" in (pending)
 }
 
 object DiscoveryServiceSpec {

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -451,6 +451,31 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
     }
   }
 
+  behavior of "enrRequest"
+
+  it should "not respond to unbonded peers" in test {
+    new Fixture {
+      override val test = for {
+        maybeResponse <- service.enrRequest(remotePeer)(())
+      } yield {
+        maybeResponse shouldBe empty
+      }
+    }
+  }
+
+  it should "respond with the local ENR record" in test {
+    new Fixture {
+      override val test = for {
+        _ <- stateRef.update {
+          _.withLastPongTimestamp(remotePeer, System.currentTimeMillis)
+        }
+        maybeResponse <- service.enrRequest(remotePeer)(())
+      } yield {
+        maybeResponse shouldBe Some(localENR)
+      }
+    }
+  }
+
   behavior of "getNode"
   it should "return the local node" in (pending)
   it should "not return a nodes which is not bonded" in (pending)

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -742,8 +742,17 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "update the address of the local node" in (pending)
   it should "increment the local ENR sequence" in (pending)
 
-  behavior of "localNode"
-  it should "return the latest local node record" in (pending)
+  behavior of "getLocalNode"
+
+  it should "return the latest local node record" in test {
+    new Fixture {
+      override val test = for {
+        node <- service.getLocalNode
+      } yield {
+        node shouldBe localNode
+      }
+    }
+  }
 }
 
 object DiscoveryServiceSpec {

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -16,7 +16,6 @@ import scala.concurrent.duration._
 
 class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
   import DiscoveryService.{State, BondingResults}
-  import DiscoveryNetworkSpec.{randomKeyPair}
   import DiscoveryServiceSpec._
   import DefaultCodecs._
 
@@ -480,7 +479,7 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "return peers for who we have an ENR record" in test {
     new Fixture {
       val caller = {
-        val (callerPublicKey, _) = randomKeyPair
+        val (callerPublicKey, _) = sigalg.newKeyPair
         val callerAddress = aRandomAddress
         Peer(callerPublicKey, callerAddress)
       }
@@ -562,7 +561,6 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
 }
 
 object DiscoveryServiceSpec {
-  import DiscoveryNetworkSpec.randomKeyPair
   import DefaultCodecs._
 
   implicit val scheduler: Scheduler = Scheduler.Implicits.global
@@ -587,14 +585,14 @@ object DiscoveryServiceSpec {
     def makeNode(publicKey: PublicKey, address: InetSocketAddress) =
       Node(publicKey, Node.Address(address.getAddress, address.getPort, address.getPort))
 
-    lazy val (localPublicKey, localPrivateKey) = randomKeyPair
+    lazy val (localPublicKey, localPrivateKey) = sigalg.newKeyPair
     lazy val localAddress = aRandomAddress
     lazy val localNode = makeNode(localPublicKey, localAddress)
     lazy val localPeer = Peer(localPublicKey, localAddress)
     lazy val localENR = EthereumNodeRecord.fromNode(localNode, localPrivateKey, seq = 1).require
 
     lazy val remoteAddress = aRandomAddress
-    lazy val (remotePublicKey, remotePrivateKey) = randomKeyPair
+    lazy val (remotePublicKey, remotePrivateKey) = sigalg.newKeyPair
     lazy val remoteNode = makeNode(remotePublicKey, remoteAddress)
     lazy val remotePeer = Peer(remotePublicKey, remoteAddress)
     lazy val remoteENR = EthereumNodeRecord.fromNode(remoteNode, remotePrivateKey, seq = 1).require

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
@@ -11,10 +11,12 @@ class MockSigAlg extends SigAlg {
   // A Secp256k1 public key is 32 bytes compressed or 64 bytes uncompressed,
   // with a 1 byte prefix showing which version it is.
   // See https://davidederosa.com/basic-blockchain-programming/elliptic-curve-keys
-  override val PublicKeyBytesSize = 65
+  //
+  // However in the discovery v4 protocol the prefix is omitted.
+  override val PublicKeyBytesSize = 64
   // Normal Secp256k1 would be 32 bytes, but here we use the same value for
   // both public and private.
-  override val PrivateKeyBytesSize = 65
+  override val PrivateKeyBytesSize = 64
   // A normal Secp256k1 signature consists of 2 bigints followed by a recovery ID,
   // but it can be just 64 bytes if that's omitted, like in the ENR.
   override val SignatureBytesSize = 65

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
@@ -16,6 +16,9 @@ class MockSigAlg extends SigAlg {
   override def sign(privateKey: PrivateKey, data: BitVector): Signature =
     Signature(xor(privateKey, data))
 
+  override def verify(publicKey: PublicKey, signature: Signature, data: BitVector): Boolean =
+    publicKey == recoverPublicKey(signature, data).require
+
   override def recoverPublicKey(signature: Signature, data: BitVector): Attempt[PublicKey] = {
     Attempt.successful(PublicKey(xor(signature, data)))
   }

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
@@ -35,6 +35,9 @@ class MockSigAlg extends SigAlg {
     Attempt.successful(PublicKey(xor(signature, data).take(PublicKeyBytesSize * 8)))
   }
 
+  override def toCompressedPublicKey(privateKey: PrivateKey): PublicKey =
+    PublicKey(privateKey)
+
   // Using XOR twice recovers the original data.
   // Pad the data so we don't lose the key if the data is shorter.
   private def xor(key: BitVector, data: BitVector): BitVector = {

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockSigAlg.scala
@@ -3,15 +3,24 @@ package io.iohk.scalanet.discovery.ethereum.v4.mocks
 import io.iohk.scalanet.discovery.crypto.{Signature, PublicKey, PrivateKey, SigAlg}
 import scodec.bits.BitVector
 import scodec.Attempt
+import scala.util.Random
 
 class MockSigAlg extends SigAlg {
   override val name = "MockSignature"
 
-  // For testing I'll use the same key for public and private,
-  // so that I can recover the public key from the signature.
   override val PrivateKeyBytesSize = 65
   override val PublicKeyBytesSize = 65
   override val SignatureBytesSize = 65
+
+  // For testing I'll use the same key for public and private,
+  // so that I can recover the public key from the signature.
+  override def newKeyPair: (PublicKey, PrivateKey) = {
+    val bytes = Array.ofDim[Byte](PrivateKeyBytesSize)
+    Random.nextBytes(bytes)
+    val privateKey = PrivateKey(BitVector(bytes))
+    val publicKey = PublicKey(privateKey)
+    publicKey -> privateKey
+  }
 
   override def sign(privateKey: PrivateKey, data: BitVector): Signature =
     Signature(xor(privateKey, data))

--- a/scalanet/discovery/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/kademlia/KRouterSpec.scala
@@ -323,7 +323,7 @@ class KRouterSpec extends FreeSpec with Eventually {
           * will finish after receiving responses from k closest nodes
           */
         val initiator = aRandomNodeRecord()
-        val xorOrder = new XorNodeOrdering[String](initiator.id)
+        val xorOrder = XorNodeOrdering[String](initiator.id)
 
         // 30 notKnownNodes + 1 bootstrap + 3 bootstrap neighbours
         val allNodes = (0 until 34)

--- a/scalanet/discovery/test/src/io/iohk/scalanet/kademlia/XorOrderingSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/kademlia/XorOrderingSpec.scala
@@ -3,6 +3,8 @@ package io.iohk.scalanet.kademlia
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import scodec.bits.BitVector
+import io.iohk.scalanet.kademlia.KRouter.NodeRecord
+import scala.collection.SortedSet
 
 class XorOrderingSpec extends FlatSpec {
 
@@ -41,5 +43,13 @@ class XorOrderingSpec extends FlatSpec {
     val rhs = BitVector.fromValidBin("0000000000000000")
 
     an[IllegalArgumentException] should be thrownBy ordering.compare(lhs, rhs)
+  }
+
+  "XorNodeOrdering" should "work with SortedSet" in {
+    implicit val ordering = XorNodeOrdering[Int](id0)
+    val node0 = NodeRecord[Int](BitVector.fromValidBin("0000"), 1, 2)
+    val node1 = NodeRecord[Int](BitVector.fromValidBin("0000"), 3, 4)
+    val nodes = SortedSet(node0, node1)
+    nodes should have size 2
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
@@ -44,6 +44,8 @@ case class InetMultiAddress(inetSocketAddress: InetSocketAddress) {
     val state = Seq(inetAddress)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
+
+  override def toString = inetSocketAddress.toString
 }
 
 object InetMultiAddress {


### PR DESCRIPTION
Builds on https://github.com/input-output-hk/scalanet/pull/95 see the [diff](https://github.com/input-output-hk/scalanet/compare/ETCM-196-discovery-v4-part1...ETCM-207-discovery-v4-part2)

Adds a `DiscoveryService` component which hopefully implements the [spec](https://github.com/ethereum/devp2p/blob/master/discv4.md#recursive-lookup).

The main differences from `KRouter` are:
* Before we talk to a node we need to `bond` with it.
* Does not respond to nodes it hasn't bonded with, unless it's a ping, which triggers a bond.
* Doesn't touch the k-bucket timestamps in any other case as when a Pong is received. I don't see a problem if it did, I just followed what Trinity does for now.
* Nodes encountered during the recursive `lookup` are bonded with, otherwise they aren't followed or returned in the closest set.
* When looking up a node, we only return the result if the ENR could be fetched; just getting it from the lookup procedure itself is not enough (they could lie about the TCP port).
* When the rest of the system asks for nodes (for gossiping for example) they only get ones where we could fetch the ENR.
* It will consider contacting all `k` closest nodes, not just alpha.
* Supports changing the external address.
* Updates the node address if it talks from a new port.
* Validates signatures.
* If the bucket the peer goes into is full and the existing node cannot be evicted, it still inserts the new candidate into the node records, just not the routing table. This way it could be resolved in `getNode` without having to look it up again, although it won't be returned in `FindNode` requests. But it _will_ be returned by `getNodes` if the rest of the system needs candidates to gossip to.
* It doesn't return the bootstrap nodes for gossiping until their ENR can be resolved.

Main differences from Trinity:
* Doesn't have a persistent ENR store.
* Only performs alpha concurrent `FindNode`
* Allows multiple `lookup`s at the same time
* Maintains the bonded status based on ID, IP and UDP port, so a new address requires new bonding.

The class is all about manipulating internal state and doing async operations, the public interface exposes very little of this. The tests have full access to all the helper methods and the state, so that I can unit tests everything by setting up and verifying the state directly.
