### PR TITLE
ETCM-254: Allow packet size violation

### DIFF
--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/PacketSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/v4/PacketSpec.scala
@@ -14,6 +14,8 @@ class PacketSpec extends FlatSpec with Matchers {
   import DefaultCodecs._
   implicit val sigalg = new MockSigAlg()
 
+  implicit val packetCodec = Packet.packetCodec(allowDecodeOverMaxPacketSize = false)
+
   val MaxPacketBytesSize = Packet.MaxPacketBitsSize / 8
   val MacBytesSize = Packet.MacBitsSize / 8
   val SigBytesSize = Packet.SigBitsSize / 8
@@ -78,6 +80,12 @@ class PacketSpec extends FlatSpec with Matchers {
       Codec.decode[Packet](nBytesAsBits(MaxPacketBytesSize + 1))
     }
   }
+
+  it should "optionally allow the data to exceed the maximum size" in {
+    val permissiblePacketCodec: Codec[Packet] = Packet.packetCodec(allowDecodeOverMaxPacketSize = true)
+    Codec.decode[Packet](nBytesAsBits(MaxPacketBytesSize * 2))(permissiblePacketCodec).isSuccessful shouldBe true
+  }
+
   it should "fail if there's less data than the hash size" in {
     expectFailure(
       s"Hash: cannot acquire ${Packet.MacBitsSize} bits from a vector that contains ${Packet.MacBitsSize - 8} bits"


### PR DESCRIPTION
Noticed that [besu](https://github.com/hyperledger/besu/blob/master/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java#L555-L556) sends all nodes in `Neighbors` that it finds, rather than just what fits into 1280 bytes as per the v4 protocol specification. To be compatible, the PR adds an optional setting to allow incoming packets to violate the size limit. `Packet.packetCodec` is no longer implicit, we have to tell it whether violations are allowed. 

The PR also adds `StaticUDPPeerGroup.Config.receiveBufferSizeBytes` which can be used to set the incoming buffer size to a lower value than the default 64KiB used by `DefaultMaxBytesRecvByteBufAllocator`. It looks like [NioDatagramChannel.doReadMessages](https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java#L241-L270) only ever reads one message at a time, so by allocating a 64KiB buffer for each message we were wasting a bit of resources. Limiting it to, say, 2*1280 like Trinity would mean that small packets like `Ping` wouldn't end up in a large buffer they don't need, and if some client tries to send much more than 1280 bytes they stop at Netty.