### PR TITLE
ETCM-240: Check and filter relayed IPs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -88,6 +88,7 @@ object scalanet extends ScalanetModule with PublishModule {
     ivy"com.github.nscala-time::nscala-time:2.22.0",
     ivy"com.chuusai::shapeless:2.3.3",
     ivy"com.typesafe.scala-logging::scala-logging:3.9.2",
+    ivy"com.github.jgonian:commons-ip-math:1.32",
     ivy"org.slf4j:slf4j-api:1.7.25",
     ivy"io.netty:netty-all:4.1.51.Final",
     ivy"org.eclipse.californium:scandium:2.0.0-M15",
@@ -123,7 +124,6 @@ object scalanet extends ScalanetModule with PublishModule {
       ivy"org.mockito:mockito-core:2.21.0",
       ivy"com.github.pureconfig::pureconfig:0.11.1",
       ivy"com.github.scopt::scopt:3.7.1",
-      ivy"org.scodec::scodec-bits:1.1.6",
       ivy"io.monix::monix:3.2.2",
       ivy"org.scala-lang.modules::scala-parser-combinators:1.1.2"
     )

--- a/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
+++ b/scalanet/discovery/it/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryKademliaIntegrationSpec.scala
@@ -3,7 +3,6 @@ package io.iohk.scalanet.discovery.ethereum.v4
 import cats.effect.Resource
 import io.iohk.scalanet.discovery.crypto.{PublicKey, PrivateKey}
 import io.iohk.scalanet.discovery.crypto.SigAlg
-import io.iohk.scalanet.discovery.ethereum.EthereumNodeRecord
 import io.iohk.scalanet.discovery.ethereum.Node
 import io.iohk.scalanet.discovery.ethereum.v4.mocks.MockSigAlg
 import io.iohk.scalanet.discovery.hash.Hash
@@ -71,11 +70,9 @@ class DiscoveryKademliaIntegrationSpec extends KademliaIntegrationSpec("Discover
           config = config
         )
       }
-      selfEnr = EthereumNodeRecord.fromNode(selfNode, privateKey, seq = 1).require
       service <- DiscoveryService[InetMultiAddress](
         privateKey,
         node = selfNode,
-        enr = selfEnr,
         config = config,
         network = network,
         toAddress = nodeAddressToInetMultiAddress

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
@@ -2,9 +2,11 @@ package io.iohk.scalanet.discovery.ethereum
 
 import io.iohk.scalanet.discovery.crypto.PublicKey
 import io.iohk.scalanet.discovery.hash.{Hash, Keccak256}
+import io.iohk.scalanet.peergroup.InetAddressOps._
 import java.net.InetAddress
 import scodec.bits.ByteVector
 import scala.util.Try
+import io.iohk.scalanet.peergroup.Addressable
 
 case class Node(id: Node.Id, address: Node.Address) {
   protected[discovery] lazy val kademliaId: Hash = Node.kademliaId(id)
@@ -23,7 +25,10 @@ object Node {
       ip: InetAddress,
       udpPort: Int,
       tcpPort: Int
-  )
+  ) {
+    protected[discovery] def checkRelay[A: Addressable](sender: A): Boolean =
+      Address.checkRelay(sender = Addressable[A].getAddress(sender).getAddress, address = ip)
+  }
   object Address {
     def fromEnr(enr: EthereumNodeRecord): Option[Node.Address] = {
       import EthereumNodeRecord.Keys
@@ -44,6 +49,18 @@ object Node {
         udp <- tryParsePort(Keys.udp6) orElse tryParsePort(Keys.udp)
         tcp <- tryParsePort(Keys.tcp6) orElse tryParsePort(Keys.tcp)
       } yield Node.Address(ip, udpPort = udp, tcpPort = tcp)
+    }
+
+    /** Check that an address relayed by the sender is valid:
+      * - Special and unspecified addresses are invalid.
+      * - LAN/loopback addresses are valid if the sender is also LAN/loopback.
+      * - Other addresses are valid.
+      */
+    def checkRelay(sender: InetAddress, address: InetAddress): Boolean = {
+      if (address.isSpecial || address.isUnspecified) false
+      else if (address.isLoopbackAddress && !sender.isLoopbackAddress) false
+      else if (address.isLAN && !sender.isLAN) false
+      else true
     }
   }
 }

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -7,9 +7,8 @@ import com.typesafe.scalalogging.LazyLogging
 import io.iohk.scalanet.discovery.crypto.{PrivateKey, PublicKey, SigAlg}
 import io.iohk.scalanet.discovery.ethereum.Node
 import io.iohk.scalanet.discovery.hash.Hash
-import io.iohk.scalanet.peergroup.PeerGroup
+import io.iohk.scalanet.peergroup.{Addressable, Channel, PeerGroup}
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
-import io.iohk.scalanet.peergroup.Channel
 import io.iohk.scalanet.peergroup.Channel.{MessageReceived, DecodingError, UnexpectedError}
 import java.util.concurrent.TimeoutException
 import java.net.InetAddress
@@ -21,6 +20,7 @@ import scodec.{Codec, Attempt}
 import scala.util.control.{NonFatal, NoStackTrace}
 import scodec.bits.BitVector
 import io.iohk.scalanet.discovery.ethereum.v4.Payload.Neighbors
+import java.net.InetSocketAddress
 
 /** Present a stateless facade implementing the RPC methods
   * that correspond to the discovery protocol messages on top
@@ -44,6 +44,12 @@ object DiscoveryNetwork {
       s"Peer(id = ${id.toHex}, address = $address)"
 
     lazy val kademliaId: Hash = Node.kademliaId(id)
+  }
+  object Peer {
+    implicit def addressable[A: Addressable]: Addressable[Peer[A]] = new Addressable[Peer[A]] {
+      override def getAddress(a: Peer[A]): InetSocketAddress =
+        Addressable[A].getAddress(a.address)
+    }
   }
 
   // Errors that stop the processing of incoming messages on a channel.

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/NodeSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/NodeSpec.scala
@@ -1,0 +1,19 @@
+package io.iohk.scalanet.discovery.ethereum
+
+import org.scalatest._
+import java.net.InetAddress
+
+class NodeSpec extends FlatSpec with Matchers {
+
+  behavior of "Node.Address.checkRelay"
+
+  val localhost = InetAddress.getByName("127.0.0.1")
+
+  it should "accept local IPs for local senders" in {
+    Node.Address.checkRelay(localhost, localhost) shouldBe true
+  }
+
+  it should "not accept local IPs from non-local senders" in {
+    Node.Address.checkRelay(address = localhost, sender = InetAddress.getByName("140.82.121.4")) shouldBe false
+  }
+}

--- a/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/NodeSpec.scala
+++ b/scalanet/discovery/test/src/io/iohk/scalanet/discovery/ethereum/NodeSpec.scala
@@ -2,18 +2,48 @@ package io.iohk.scalanet.discovery.ethereum
 
 import org.scalatest._
 import java.net.InetAddress
+import org.scalatest.prop.TableDrivenPropertyChecks
+import io.iohk.scalanet.peergroup.InetMultiAddress
+import java.net.InetSocketAddress
 
-class NodeSpec extends FlatSpec with Matchers {
+class NodeSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
 
   behavior of "Node.Address.checkRelay"
 
-  val localhost = InetAddress.getByName("127.0.0.1")
+  val cases = Table(
+    ("sender", "relayed", "isValid"),
+    ("localhost", "localhost", true),
+    ("127.0.0.1", "192.168.1.2", true),
+    ("127.0.0.1", "140.82.121.4", true),
+    ("140.82.121.4", "192.168.1.2", false),
+    ("140.82.121.4", "52.206.42.104", true),
+    ("140.82.121.4", "0.0.0.0", false),
+    ("140.82.121.4", "255.255.255.255", false),
+    ("127.0.0.1", "0.0.0.0", false),
+    ("127.0.0.1", "192.175.48.127", false)
+  )
 
-  it should "accept local IPs for local senders" in {
-    Node.Address.checkRelay(localhost, localhost) shouldBe true
+  it should "correctly calculate the flag for sender-address pairs" in {
+    forAll(cases) {
+      case (sender, relayed, isValid) =>
+        withClue(s"$relayed from $sender") {
+          val senderIP = InetAddress.getByName(sender)
+          val relayedIP = InetAddress.getByName(relayed)
+
+          Node.Address.checkRelay(sender = senderIP, address = relayedIP) shouldBe isValid
+        }
+    }
   }
 
-  it should "not accept local IPs from non-local senders" in {
-    Node.Address.checkRelay(address = localhost, sender = InetAddress.getByName("140.82.121.4")) shouldBe false
+  it should "work on the address instance" in {
+    forAll(cases) {
+      case (sender, relayed, isValid) =>
+        withClue(s"$relayed from $sender") {
+          val nodeAddress = Node.Address(InetAddress.getByName(relayed), 30000, 40000)
+          val senderMulti = InetMultiAddress(new InetSocketAddress(InetAddress.getByName(sender), 50000))
+
+          nodeAddress.checkRelay(senderMulti) shouldBe isValid
+        }
+    }
   }
 }

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetAddressOps.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetAddressOps.scala
@@ -1,0 +1,99 @@
+package io.iohk.scalanet.peergroup
+
+import com.github.jgonian.ipmath.{Ipv6Range, Ipv4Range, Ipv4, Ipv6}
+import java.net.{InetAddress, Inet4Address, Inet6Address}
+import scala.language.implicitConversions
+
+class InetAddressOps(val address: InetAddress) extends AnyVal {
+  import InetAddressOps._
+
+  def isIPv4: Boolean =
+    address.isInstanceOf[Inet4Address]
+
+  def isIPv6: Boolean =
+    address.isInstanceOf[Inet6Address]
+
+  def isSpecial: Boolean =
+    address.isMulticastAddress || isIPv4 && isInRange4(special4) || isIPv6 && isInRange6(special6)
+
+  def isLAN: Boolean =
+    address.isLoopbackAddress || isIPv4 && isInRange4(lan4) || isIPv6 && isInRange6(lan6)
+
+  def isUnspecified: Boolean =
+    address == unspecified4 || address == unspecified6
+
+  private def isInRange4(infos: List[Ipv4Range]): Boolean = {
+    val ip = Ipv4.of(address.getHostAddress)
+    infos.exists(_.contains(ip))
+  }
+
+  private def isInRange6(infos: List[Ipv6Range]): Boolean = {
+    val ip = Ipv6.of(address.getHostAddress)
+    infos.exists(_.contains(ip))
+  }
+}
+
+object InetAddressOps {
+  implicit def toInetAddressOps(address: InetAddress): InetAddressOps =
+    new InetAddressOps(address)
+
+  // https://tools.ietf.org/html/rfc5735.html
+  private val unspecified4 = InetAddress.getByName("0.0.0.0")
+
+  // https://tools.ietf.org/html/rfc2373.html
+  private val unspecified6 = InetAddress.getByName("0:0:0:0:0:0:0:0")
+
+  // https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+  private val special4 =
+    List(
+      "100.64.0.0/10", //	Shared Address Space
+      "169.254.0.0/16", //	Link Local
+      "192.0.0.0/24", // [2]	IETF Protocol Assignments
+      "192.0.0.0/29", //	IPv4 Service Continuity Prefix
+      "192.0.0.8/32", //	IPv4 dummy address
+      "192.0.0.9/32", //	Port Control Protocol Anycast
+      "192.0.0.10/32", //	Traversal Using Relays around NAT Anycast
+      "192.0.0.170/32", //  NAT64/DNS64 Discovery
+      "192.0.0.171/32", //	NAT64/DNS64 Discovery
+      "192.0.2.0/24", //	Documentation (TEST-NET-1)
+      "192.31.196.0/24", //	AS112-v4
+      "192.52.193.0/24", //	AMT
+      "192.88.99.0/24", //	Deprecated (6to4 Relay Anycast)
+      "192.175.48.0/24", //	Direct Delegation AS112 Service
+      "198.18.0.0/15", //	Benchmarking
+      "198.51.100.0/24", //	Documentation (TEST-NET-2)
+      "203.0.113.0/24", //	Documentation (TEST-NET-3)
+      "240.0.0.0/4", //	Reserved
+      "255.255.255.255/32" //	Limited Broadcast
+    ).map(Ipv4Range.parse(_))
+
+  // https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+  private val special6 =
+    List(
+      "100::/64",
+      "2001::/32",
+      "2001:1::1/128",
+      "2001:2::/48",
+      "2001:3::/32",
+      "2001:4:112::/48",
+      "2001:5::/32",
+      "2001:10::/28",
+      "2001:20::/28",
+      "2001:db8::/32",
+      "2002::/16"
+    ).map(Ipv6Range.parse(_))
+
+  private val lan4 =
+    List(
+      "0.0.0.0/8", //	"This host on this network"
+      "10.0.0.0/8", // Private-Use
+      "172.16.0.0/12", // Private-Use
+      "192.168.0.0/16" // Private-Use
+    ).map(Ipv4Range.parse(_))
+
+  private val lan6 =
+    List(
+      "fe80::/10", // Link-Local
+      "fc00::/7" // Unique-Local
+    ).map(Ipv6Range.parse(_))
+}

--- a/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/InetMultiAddress.scala
@@ -8,6 +8,10 @@ trait Addressable[A] {
 
 object Addressable {
   def apply[A](implicit sh: Addressable[A]): Addressable[A] = sh
+
+  implicit val `Addressable[InetSocketAddress]` : Addressable[InetSocketAddress] = new Addressable[InetSocketAddress] {
+    override def getAddress(a: InetSocketAddress): InetSocketAddress = a
+  }
 }
 
 /**

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/InetAddressOpsSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/InetAddressOpsSpec.scala
@@ -1,0 +1,40 @@
+package io.iohk.scalanet.peergroup
+
+import java.net.InetAddress
+
+import org.scalatest._
+
+class InetAddressOpsSpec extends FlatSpec with Matchers {
+  import InetAddressOps._
+
+  behavior of "isUnspecified"
+
+  it should "return true for IPv4 unspecified" in {
+    InetAddress.getByName("0.0.0.0").isUnspecified shouldBe true
+  }
+  it should "return true for IPv6 unspecified" in {
+    InetAddress.getByName("0:0:0:0:0:0:0:0").isUnspecified shouldBe true
+  }
+
+  behavior of "isSpecial"
+
+  it should "return true for IPv4 specials" in {
+    InetAddress.getByName("192.88.99.0").isSpecial shouldBe true
+  }
+  it should "return true for IPv6 specials" in {
+    InetAddress.getByName("2001:4:112::").isSpecial shouldBe true
+  }
+  it should "return false for loopback" in {
+    InetAddress.getByName("127.0.0.1").isSpecial shouldBe false
+    InetAddress.getByName("::1").isSpecial shouldBe false
+  }
+
+  behavior of "isLAN"
+
+  it should "return true for IPv4 loopback" in {
+    InetAddress.getByName("127.0.0.1").isLAN shouldBe true
+  }
+  it should "return true for IPv6 loopback" in {
+    InetAddress.getByName("::1").isLAN shouldBe true
+  }
+}

--- a/scalanet/test/src/io/iohk/scalanet/peergroup/InetAddressOpsSpec.scala
+++ b/scalanet/test/src/io/iohk/scalanet/peergroup/InetAddressOpsSpec.scala
@@ -4,37 +4,45 @@ import java.net.InetAddress
 
 import org.scalatest._
 
-class InetAddressOpsSpec extends FlatSpec with Matchers {
+class InetAddressOpsSpec extends FlatSpec with Matchers with Inspectors {
   import InetAddressOps._
 
-  behavior of "isUnspecified"
+  case class TestCase(ip: String, isUnspecified: Boolean = false, isSpecial: Boolean = false, isLAN: Boolean = false)
 
-  it should "return true for IPv4 unspecified" in {
-    InetAddress.getByName("0.0.0.0").isUnspecified shouldBe true
-  }
-  it should "return true for IPv6 unspecified" in {
-    InetAddress.getByName("0:0:0:0:0:0:0:0").isUnspecified shouldBe true
-  }
+  val cases = List(
+    TestCase("0.0.0.0", isUnspecified = true, isLAN = true),
+    TestCase("0.0.0.1", isLAN = true),
+    TestCase("0:0:0:0:0:0:0:0", isUnspecified = true),
+    TestCase("127.0.0.1", isLAN = true),
+    TestCase("::1", isLAN = true),
+    TestCase("192.168.1.2", isLAN = true),
+    TestCase("192.175.47"),
+    TestCase("192.175.48.0", isSpecial = true),
+    TestCase("192.175.48.127", isSpecial = true),
+    TestCase("192.175.48.255", isSpecial = true),
+    TestCase("192.175.49"),
+    TestCase("255.255.255.255", isSpecial = true),
+    TestCase("2001:4:112::", isSpecial = true),
+    TestCase("140.82.121.4")
+  )
 
-  behavior of "isSpecial"
+  behavior of "InetAddressOps"
 
-  it should "return true for IPv4 specials" in {
-    InetAddress.getByName("192.88.99.0").isSpecial shouldBe true
-  }
-  it should "return true for IPv6 specials" in {
-    InetAddress.getByName("2001:4:112::").isSpecial shouldBe true
-  }
-  it should "return false for loopback" in {
-    InetAddress.getByName("127.0.0.1").isSpecial shouldBe false
-    InetAddress.getByName("::1").isSpecial shouldBe false
-  }
-
-  behavior of "isLAN"
-
-  it should "return true for IPv4 loopback" in {
-    InetAddress.getByName("127.0.0.1").isLAN shouldBe true
-  }
-  it should "return true for IPv6 loopback" in {
-    InetAddress.getByName("::1").isLAN shouldBe true
+  it should "correctly calculate each flag" in {
+    forAll(cases) {
+      case TestCase(ip, isUnspecified, isSpecial, isLAN) =>
+        withClue(ip) {
+          val addr = InetAddress.getByName(ip)
+          withClue("isUnspecified") {
+            addr.isUnspecified shouldBe isUnspecified
+          }
+          withClue("isSpecial") {
+            addr.isSpecial shouldBe isSpecial
+          }
+          withClue("isLAN") {
+            addr.isLAN shouldBe isLAN
+          }
+        }
+    }
   }
 }


### PR DESCRIPTION
Filters out IP addresses from neighbours and the ENR results that aren't valid for a variety of reasons, such as being loopback addresses only the sender can talk to, or special/reserved IPs.