### PR TITLE
ETCM-168: ETC testnet fixes

### DIFF
--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -22,6 +22,7 @@ object EthereumNodeRecord {
   case class Content(
       // Nodes should increment this number whenever their properties change, like their address, and re-publish.
       seq: Long,
+      // Normally clients treat the values as RLP, however we don't have access to the RLP types here, hence it's just bytes.
       attrs: SortedMap[ByteVector, ByteVector]
   )
 
@@ -52,6 +53,9 @@ object EthereumNodeRecord {
 
     /** IPv6-specific UDP port, big endian integer */
     val udp6 = key("udp6")
+
+    /** The keys above have pre-defined meaning, but there can be arbitrary entries in the map. */
+    val Predefined: Set[ByteVector] = Set(id, secp256k1, ip, tcp, udp, ip6, tcp6, udp6)
   }
 
   def apply(signature: Signature, seq: Long, attrs: (ByteVector, ByteVector)*): EthereumNodeRecord =

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/Node.scala
@@ -42,7 +42,7 @@ object Node {
         tryParse[InetAddress](key)(bytes => InetAddress.getByAddress(bytes.toArray))
 
       def tryParsePort(key: ByteVector): Option[Int] =
-        tryParse[Int](key)(bytes => bytes.toInt())
+        tryParse[Int](key)(bytes => bytes.toInt(signed = false))
 
       for {
         ip <- tryParseIP(Keys.ip6) orElse tryParseIP(Keys.ip)

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -815,7 +815,7 @@ object DiscoveryService {
         val tryEnroll = for {
           nodeId <- stateRef.get.map(_.node.id)
           bootstrapPeers = config.knownPeers.toList.map(toPeer).filterNot(_.id == nodeId)
-          maybeBootstrapEnrs <- bootstrapPeers.traverse(fetchEnr(_, delay = true))
+          maybeBootstrapEnrs <- Task.parTraverseN(config.kademliaAlpha)(bootstrapPeers)(fetchEnr(_, delay = true))
           result <- if (maybeBootstrapEnrs.exists(_.isDefined)) {
             lookup(nodeId).as(true)
           } else {

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/Payload.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/Payload.scala
@@ -18,7 +18,7 @@ object Payload {
   sealed trait Response extends Payload
 
   trait HasExpiration[T <: Payload] {
-    // Absolute UNIX timestamp.
+    // Absolute UNIX timestamp: seconds since epoch.
     def expiration: Long
     def withExpiration(at: Long): T
   }
@@ -28,7 +28,6 @@ object Payload {
       version: Int,
       from: Node.Address,
       to: Node.Address,
-      // Absolute UNIX timestamp.
       expiration: Long,
       // Current ENR sequence number of the sender.
       enrSeq: Option[Long]


### PR DESCRIPTION
Fixes necessary for connecting to the ETC testnet:
- [x] `expiration` was supposed to be seconds, not millis, since epoch
- [x] implement Ping hash workaround for Parity nodes
- [x] ports in the ENR should be treated as unsigned its, otherwise they may be interpreted as negative values because other clients send shorter, 2 byte values