### PR TITLE
ETCM-168: ENR content constructor and extra logging

### DIFF
--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -25,6 +25,10 @@ object EthereumNodeRecord {
       // Normally clients treat the values as RLP, however we don't have access to the RLP types here, hence it's just bytes.
       attrs: SortedMap[ByteVector, ByteVector]
   )
+  object Content {
+    def apply(seq: Long, attrs: (ByteVector, ByteVector)*): Content =
+      Content(seq, SortedMap(attrs: _*))
+  }
 
   object Keys {
     private def key(k: String): ByteVector =
@@ -61,14 +65,14 @@ object EthereumNodeRecord {
   def apply(signature: Signature, seq: Long, attrs: (ByteVector, ByteVector)*): EthereumNodeRecord =
     EthereumNodeRecord(
       signature,
-      EthereumNodeRecord.Content(seq, SortedMap(attrs: _*))
+      EthereumNodeRecord.Content(seq, attrs: _*)
     )
 
   def apply(privateKey: PrivateKey, seq: Long, attrs: (ByteVector, ByteVector)*)(
       implicit sigalg: SigAlg,
       codec: Codec[Content]
   ): Attempt[EthereumNodeRecord] = {
-    val content = EthereumNodeRecord.Content(seq, SortedMap(attrs: _*))
+    val content = EthereumNodeRecord.Content(seq, attrs: _*)
     codec.encode(content).map { data =>
       val sig = sigalg.removeRecoveryId(sigalg.sign(privateKey, data))
       EthereumNodeRecord(sig, content)

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -134,9 +134,8 @@ object DiscoveryNetwork {
                     }
 
                   case Attempt.Failure(err) =>
-                    Task.raiseError(
-                      new PacketException(s"Failed to unpack message: $err")
-                    )
+                    Task(logger.debug(s"Failed to unpack packet: $err; ${packet.show}")) >>
+                      Task.raiseError(new PacketException(s"Failed to unpack message: $err"))
                 }
               }
 

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/Packet.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/Packet.scala
@@ -1,5 +1,6 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
+import cats.Show
 import io.iohk.scalanet.discovery.hash.{Hash, Keccak256}
 import io.iohk.scalanet.discovery.crypto.{SigAlg, PrivateKey, PublicKey, Signature}
 import scodec.bits.BitVector
@@ -86,4 +87,8 @@ object Packet {
       publicKey <- sigalg.recoverPublicKey(packet.signature, packet.data)
       payload <- codec.decodeValue(packet.data)
     } yield (payload, publicKey)
+
+  implicit val show: Show[Packet] = Show.show[Packet] { p =>
+    s"""Packet(hash = hex"${p.hash.toHex}", signature = hex"${p.signature.toHex}", data = hex"${p.data.toHex}")"""
+  }
 }


### PR DESCRIPTION
Adds a convenience constructor to `EthereumNodeRecord.Conent`. 

This was supposed to have been done in https://github.com/input-output-hk/scalanet/pull/100 but I put it at the wrong place.

Also added extra logging to provide feedback about the enrollment, and a debug about packets that failed to deserialize.