### PR TITLE
ETCM-168: Fix stalled enrollments

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -68,7 +68,7 @@ trait ScalanetModule extends ScalaModule {
 trait ScalanetPublishModule extends PublishModule {
   def description: String
 
-  override def publishVersion = "0.4-SNAPSHOT"
+  override def publishVersion = "0.4.1-SNAPSHOT"
 
   override def pomSettings = PomSettings(
     description = description,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -797,7 +797,7 @@ object DiscoveryService {
           ) >>
             Task
               .parTraverseUnordered(contacts)(fetchNeighbors)
-              .map(_.flatten.distinct)
+              .map(_.flatten.distinct.filterNot(neighbors))
               .flatMap(bondNeighbors)
               .flatMap { newNeighbors =>
                 val nextClosest = (closest ++ newNeighbors).take(config.kademliaBucketSize)


### PR DESCRIPTION
Sometimes `enroll` seems to never finish. After debugging I think it's the `bondNeighbors`.

I couldn't see anything obvious in the code, but it's conceivable that if there are multiple bonding attempts then a deferred somehow got stuck in the map. Instead of waiting on it forever it now returns a result after a timeout.

Also limited the number of parallel bonding attempts to `alpha`.