### PR TITLE
ETCM-328: External IP resolver

### DIFF
--- a/scalanet/src/io/iohk/scalanet/peergroup/ExternalAddressResolver.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ExternalAddressResolver.scala
@@ -1,0 +1,42 @@
+package io.iohk.scalanet.peergroup
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.net.{InetAddress, URL}
+
+import monix.eval.Task
+import scala.util.control.NonFatal
+
+/** Resolve the external address based on a list of URLs that each return the IP of the caller. */
+class ExternalAddressResolver(urls: List[String]) {
+  def resolve: Task[Option[InetAddress]] =
+    ExternalAddressResolver.checkUrls(urls)
+}
+
+object ExternalAddressResolver {
+  val default = new ExternalAddressResolver(List("http://checkip.amazonaws.com", "http://bot.whatismyipaddress.com"))
+
+  /** Retrieve the external address from a URL that returns a single line containing the IP. */
+  def checkUrl(url: String): Task[InetAddress] = Task.async { cb =>
+    try {
+      val ipCheckUrl = new URL(url)
+      val in: BufferedReader = new BufferedReader(new InputStreamReader(ipCheckUrl.openStream()))
+      cb.onSuccess(InetAddress.getByName(in.readLine()))
+    } catch {
+      case NonFatal(ex) => cb.onError(ex)
+    }
+  }
+
+  /** Try multiple URLs until an IP address is found. */
+  def checkUrls(urls: List[String]): Task[Option[InetAddress]] = {
+    if (urls.isEmpty) {
+      Task.now(None)
+    } else {
+      checkUrl(urls.head).attempt.flatMap {
+        case Left(_) =>
+          checkUrls(urls.tail)
+        case Right(value) =>
+          Task.now(Some(value))
+      }
+    }
+  }
+}

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/ExternalAddressResolverSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/ExternalAddressResolverSpec.scala
@@ -1,0 +1,21 @@
+package io.iohk.scalanet.peergroup
+
+import org.scalatest._
+import scala.concurrent.duration._
+import monix.execution.Scheduler.Implicits.global
+
+class ExternalAddressResolverSpec extends FlatSpec with Matchers {
+
+  behavior of "ExternalAddressResolver"
+
+  it should "resolve the external IP" in {
+    val maybeAddress = ExternalAddressResolver.default.resolve.runSyncUnsafe(5.seconds)
+
+    maybeAddress should not be empty
+    maybeAddress.get.isLoopbackAddress shouldBe false
+  }
+
+  it should "return None if all resolutions fail" in {
+    ExternalAddressResolver.checkUrls(List("", "404.html")).runSyncUnsafe(1.seconds) shouldBe empty
+  }
+}


### PR DESCRIPTION
Adds a simple `ExternalAddressResolver` to Scalanet that can be used to get the externally visible IP address of the node. Doesn't do any port forwarding.
