### PR TITLE
ETCM-393: Expose the lookup methods on DiscoveryService

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -68,7 +68,7 @@ trait ScalanetModule extends ScalaModule {
 trait ScalanetPublishModule extends PublishModule {
   def description: String
 
-  override def publishVersion = "0.4.2-SNAPSHOT"
+  override def publishVersion = "0.4.3-SNAPSHOT"
 
   override def pomSettings = PomSettings(
     description = description,

--- a/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -777,7 +777,7 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
 
       override val test = for {
         _ <- addRemotePeer
-        _ <- service.lookupRandom()
+        _ <- service.lookupRandom
         state <- stateRef.get
       } yield {
         // We should bond with nodes along the way, so in the end there should


### PR DESCRIPTION
Allow `lookup` and `lookupRandom` to be called on the `DiscoveryService` so Mantis can trigger searches on demand, rather than wait on the fixed schedule to yield more peers to connect to.