### PR TITLE
ETCM-414: Incoming pings don't trigger bonds until enroll is finished.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mill __.test
 
 A single test suite can be executed with the `single` helper command, for example:
 ```bash
-mill scalanet.test.single io.iohk.scalanet.crypto.SignatureVerificationSpec
+mill scalanet.ut.single io.iohk.scalanet.crypto.SignatureVerificationSpec
 ```
 
 ### Publishing

--- a/build.sc
+++ b/build.sc
@@ -68,7 +68,7 @@ trait ScalanetModule extends ScalaModule {
 trait ScalanetPublishModule extends PublishModule {
   def description: String
 
-  override def publishVersion = "0.4.3-SNAPSHOT"
+  override def publishVersion = "0.4.4-SNAPSHOT"
 
   override def pomSettings = PomSettings(
     description = description,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -95,7 +95,8 @@ object DiscoveryService {
           // Start handling requests, we need them during enrolling so the peers can ping and bond with us.
           cancelToken <- network.startHandling(service)
           // Contact the bootstrap nodes.
-          enroll = service.enroll()
+          // Setting the enrolled status here because we could potentially repeat enrollment until it succeeds.
+          enroll = service.enroll().guarantee(stateRef.update(_.setEnrolled))
           // Periodically discover new nodes.
           discover = service.lookupRandom.delayExecution(config.discoveryPeriod).loopForever
           // Enrollment can be run in the background if it takes very long.
@@ -152,7 +153,9 @@ object DiscoveryService {
       // Deferred results so we can ensure there's only one concurrent Ping to a given peer.
       bondingResultsMap: Map[Peer[A], BondingResults],
       // Deferred ENR fetches so we only do one at a time to a given peer.
-      fetchEnrMap: Map[Peer[A], FetchEnrResult]
+      fetchEnrMap: Map[Peer[A], FetchEnrResult],
+      // Indicate whether enrollment hash finished.
+      hasEnrolled: Boolean
   ) {
     def isSelf(peer: Peer[A]): Boolean =
       peer.id == node.id
@@ -230,6 +233,9 @@ object DiscoveryService {
         kBuckets = kBuckets.remove(Node.kademliaId(peerId)),
         kademliaIdToNodeId = kademliaIdToNodeId - Node.kademliaId(peerId)
       )
+
+    def setEnrolled: State[A] =
+      copy(hasEnrolled = true)
   }
   protected[v4] object State {
     def apply[A](
@@ -245,7 +251,8 @@ object DiscoveryService {
       enrMap = Map(node.id -> enr),
       lastPongTimestampMap = Map.empty[Peer[A], Timestamp],
       bondingResultsMap = Map.empty[Peer[A], BondingResults],
-      fetchEnrMap = Map.empty[Peer[A], FetchEnrResult]
+      fetchEnrMap = Map.empty[Peer[A], FetchEnrResult],
+      hasEnrolled = false
     )
   }
 
@@ -328,6 +335,10 @@ object DiscoveryService {
           for {
             // Complete any deferred waiting for a ping from this peer, if we initiated the bonding.
             _ <- completePing(caller)
+            // To protect against an eclipse attack filling up the k-table after a reboot,
+            // only try to bond with an incoming Ping's peer after the initial enrollment
+            // hash finished.
+            hasEnrolled <- stateRef.get.map(_.hasEnrolled)
             _ <- isBonded(caller)
               .ifM(
                 // We may already be bonded but the remote node could have changed its address.
@@ -338,6 +349,7 @@ object DiscoveryService {
                 bond(caller)
               )
               .startAndForget
+              .whenA(hasEnrolled)
             // Return the latet local ENR sequence.
             enrSeq <- localEnrSeq
           } yield Some(Some(enrSeq))


### PR DESCRIPTION
The PR implements _Countermeasure 6_ from the [eclipse attack paper](https://eprint.iacr.org/2018/236.pdf).