### PR TITLE
ETCM-443: Fix the KTable and the kademlia ID mapping getting out of sync

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -68,7 +68,7 @@ trait ScalanetModule extends ScalaModule {
 trait ScalanetPublishModule extends PublishModule {
   def description: String
 
-  override def publishVersion = "0.4.3-SNAPSHOT"
+  override def publishVersion = "0.4.4-SNAPSHOT"
 
   override def pomSettings = PomSettings(
     description = description,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryService.scala
@@ -185,8 +185,13 @@ object DiscoveryService {
       )
     }
 
+    /** Update the timestamp of the peer in the K-table, if it's still part of it. */
     def withTouch(peer: Peer[A]): State[A] =
-      copy(kBuckets = kBuckets.touch(peer.kademliaId))
+      if (kBuckets.contains(peer.kademliaId))
+        copy(kBuckets = kBuckets.touch(peer.kademliaId))
+      else
+        // Not adding because `kademliaIdToNodeId` and `nodeMap` may no longer have this peer.
+        this
 
     def clearBondingResults(peer: Peer[A]): State[A] =
       copy(bondingResultsMap = bondingResultsMap - peer)

--- a/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
+++ b/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryServiceSpec.scala
@@ -983,6 +983,30 @@ class DiscoveryServiceSpec extends AsyncFlatSpec with Matchers {
       }
     }
   }
+
+  behavior of "withTouch"
+
+  it should "not touch a peer not already in the k-table" in test {
+    new Fixture {
+      override val test = for {
+        state0 <- stateRef.get
+        state1 = state0.withTouch(remotePeer)
+        state2 = state1.withEnrAndAddress(remotePeer, remoteENR, remoteNode.address)
+        _ <- Task.sleep(1.milli) // If we're too quick then TimeSet will assign the same timestamp.
+        state3 = state2.withTouch(remotePeer)
+      } yield {
+        val peerId = remotePeer.kademliaId
+
+        state0.kBuckets.contains(peerId) shouldBe false
+        state1.kBuckets.contains(peerId) shouldBe false
+        state2.kBuckets.contains(peerId) shouldBe true
+
+        val (_, bucket2) = state2.kBuckets.getBucket(peerId)
+        val (_, bucket3) = state3.kBuckets.getBucket(peerId)
+        bucket2.timestamps should not equal bucket3.timestamps
+      }
+    }
+  }
 }
 
 object DiscoveryServiceSpec {

--- a/scalanet/discovery/ut/src/io/iohk/scalanet/kademlia/KBucketsSpec.scala
+++ b/scalanet/discovery/ut/src/io/iohk/scalanet/kademlia/KBucketsSpec.scala
@@ -36,6 +36,10 @@ class KBucketsSpec extends FlatSpec {
     kb.add(v).contains(v) shouldBe true
   }
 
+  they should "retrieve any node added via touch" in forAll(genBitVector()) { v =>
+    kb.touch(v).contains(v) shouldBe true
+  }
+
   they should "not retrieve any node removed via remove" in forAll(genBitVector()) { v =>
     kb.add(v).remove(v).contains(v) shouldBe false
   }


### PR DESCRIPTION
I mistakenly assumed that `KBuckets.add` adds a record while `KBuckets.touch` only updates the timestamp. Instead `TimeSet.touch` is effectively just an [alias](https://github.com/input-output-hk/scalanet/blob/develop/scalanet/discovery/src/io/iohk/scalanet/kademlia/TimeSet.scala#L31-L32) for `+`. Not sure if that was the intention, because [KBuckets.touch](https://github.com/input-output-hk/scalanet/blob/develop/scalanet/discovery/src/io/iohk/scalanet/kademlia/KBuckets.scala#L112) says it should move an item to the end of the list, and `add` and `touch` are now doing the same thing which is slightly confusing, but [TimeSetSpec](https://github.com/input-output-hk/scalanet/blob/develop/scalanet/discovery/ut/src/io/iohk/scalanet/kademlia/TimeSetSpec.scala#L18) clearly assumes touching will add records.

The PR changes `DiscoveryService.State.withTouch` to only touch the peer if it's contained in the K-table, to avoid the situation where an unresponsive peer is removed, but an async touch (perhaps due to an eviction check) puts it back into the table but not the ID mapping.