### PR TITLE
[FIX] Fix missing arg

### DIFF
--- a/scalanet/src/io/iohk/scalanet/peergroup/CloseableQueue.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/CloseableQueue.scala
@@ -85,7 +85,7 @@ object CloseableQueue {
   type Closed = Closed.type
 
   /** Create a queue with a given capacity; 0 or negative means unbounded. */
-  def apply[A](capacity: Int, channelType: ChannelType = ChannelType.MPMC) = {
+  def apply[A](capacity: Int, channelType: ChannelType) = {
     val buffer = capacity match {
       case i if i <= 0 => BufferCapacity.Unbounded()
       // Capacity is approximate and a power of 2, min value 2.
@@ -98,5 +98,5 @@ object CloseableQueue {
   }
 
   def unbounded[A](channelType: ChannelType = ChannelType.MPMC) =
-    apply[A](capacity = 0)
+    apply[A](capacity = 0, channelType)
 }

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/CloseableQueueSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/CloseableQueueSpec.scala
@@ -1,9 +1,10 @@
 package io.iohk.scalanet.peergroup
 
 import cats.implicits._
-import monix.execution.Scheduler
+import monix.execution.{ChannelType, Scheduler}
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
+
 import scala.concurrent.duration._
 import org.scalatest.compatible.Assertion
 
@@ -14,7 +15,7 @@ class CloseableQueueSpec extends FlatSpec with Matchers {
   def testQueue(
       capacity: Int = 0
   )(f: CloseableQueue[String] => Task[Assertion]): Unit = {
-    CloseableQueue[String](capacity).flatMap(f).void.runSyncUnsafe(5.seconds)
+    CloseableQueue[String](capacity, ChannelType.MPMC).flatMap(f).void.runSyncUnsafe(5.seconds)
   }
 
   behavior of "ClosableQueue"


### PR DESCRIPTION
Use proper arg when using `ClosableQueue.unbounded` constructor