### PR TITLE
Wrong artifact names published during cross-build

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -120,6 +120,8 @@ class ScalanetModule(crossVersion: String) extends Module {
   //object scalanet extends ScalaModule with PublishModule with ScoverageModule {
   object scalanet extends ScalanetModule with ScalanetPublishModule {
 
+    override def artifactName = "scalanet"
+
     override val description =
       "Asynchronous, strongly typed, resource-managed networking library, written in Scala with support for a variety of network technologies"
 
@@ -147,6 +149,8 @@ class ScalanetModule(crossVersion: String) extends Module {
     object ut extends TestModule
 
     object discovery extends ScalanetModule with ScalanetPublishModule {
+
+      override def artifactName = "scalanet-discovery"
 
       override val description =
         "Implementation of peer-to-peer discovery algorithms such as that of Ethereum."


### PR DESCRIPTION
There's an error in artifact names:
Expected:
```
[186/186] mill.scalalib.PublishModule.publishAll 
Uploading io/iohk/scalanet_2.12/0.5.1-SNAPSHOT/scalanet_2.12-0.5.1-SNAPSHOT.jar
...
```

Got:
```
[186/186] mill.scalalib.PublishModule.publishAll 
Uploading io/iohk/csm-2.12.10-scalanet_2.12/0.5.1-SNAPSHOT/csm-2.12.10-scalanet_2.12-0.5.1-SNAPSHOT.jar
Uploading io/iohk/csm-2.12.10-scalanet_2.12/0.5.1-SNAPSHOT/csm-2.12.10-scalanet_2.12-0.5.1-SNAPSHOT.jar.md5
Uploading io/iohk/csm-2.12.10-scalanet_2.12/0.5.1-SNAPSHOT/csm-2.12.10-scalanet_2.12-0.5.1-SNAPSHOT.jar.sha1
```

Added overrides for the artifact names in build.