### PR TITLE
[PM-2632] socks5 proxy support

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -101,7 +101,7 @@ class ScalanetModule(crossVersion: String) extends Module {
   trait ScalanetPublishModule extends PublishModule {
     def description: String
 
-    override def publishVersion = "0.5.1-SNAPSHOT"
+    override def publishVersion = "0.5.2-SNAPSHOT"
 
     override def pomSettings = PomSettings(
       description = description,

--- a/build.sc
+++ b/build.sc
@@ -12,8 +12,8 @@ class ScalanetModule(crossVersion: String) extends Module {
 
   // A cross build is now a `root` of the module:
   // > mill show csm[2.13.4].scalanet.sources
-  // [1/1] show 
-  // [1/1] show > [1/1] csm[2.13.4].scalanet.sources 
+  // [1/1] show
+  // [1/1] show > [1/1] csm[2.13.4].scalanet.sources
   // [
   //     "ref:c984eca8: ../csm/2.13.4/scalanet/src"
   // ]
@@ -24,7 +24,6 @@ class ScalanetModule(crossVersion: String) extends Module {
   //            // some output omitted //
   //     "ref:c984eca8: ../scalanet/src"
   override def millSourcePath = super.millSourcePath / os.up / os.up
-
 
   // scala 2.12 - only options
   // it causes errors when built against 2.13 (and vice-versa):
@@ -37,11 +36,10 @@ class ScalanetModule(crossVersion: String) extends Module {
     "-Ywarn-value-discard"
   )
 
-
   // scala 2.13 might have another set of options
   private val `scala 2.13 options`: Seq[String] = Nil
 
-  trait ScalanetModule extends ScalaModule { 
+  trait ScalanetModule extends ScalaModule {
     override def scalaVersion = crossVersion
 
     override def repositories =
@@ -63,7 +61,7 @@ class ScalanetModule(crossVersion: String) extends Module {
       "utf-8"
     )
 
-    private val versionOptions = crossVersion.take(4) match { 
+    private val versionOptions = crossVersion.take(4) match {
       case "2.12" => `scala 2.12 options`
       case "2.13" => `scala 2.13 options`
     }
@@ -84,7 +82,8 @@ class ScalanetModule(crossVersion: String) extends Module {
         ivy"org.scalacheck::scalacheck:1.14.0",
         ivy"ch.qos.logback:logback-core:1.2.3",
         ivy"ch.qos.logback:logback-classic:1.2.3",
-        ivy"org.mockito:mockito-core:2.21.0"
+        ivy"org.mockito:mockito-core:2.21.0",
+        ivy"com.github.mike10004:fengyouchao-sockslib:1.0.6"
       )
 
       override def moduleDeps: Seq[JavaModule] =
@@ -95,7 +94,6 @@ class ScalanetModule(crossVersion: String) extends Module {
       }
     }
   }
-
 
   // In objects inheriting this trait, use `override def moduleDeps: Seq[PublishModule]`
   // to point at other modules that also get published. In other cases such as tests

--- a/build.sc
+++ b/build.sc
@@ -101,7 +101,7 @@ class ScalanetModule(crossVersion: String) extends Module {
   trait ScalanetPublishModule extends PublishModule {
     def description: String
 
-    override def publishVersion = "0.5.2-SNAPSHOT"
+    override def publishVersion = "0.6.0-SNAPSHOT"
 
     override def pomSettings = PomSettings(
       description = description,

--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/codecs/DefaultCodecs.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/codecs/DefaultCodecs.scala
@@ -13,7 +13,6 @@ import scala.collection.SortedMap
 import scala.math.Ordering.Implicits._
 import java.net.InetAddress
 
-
 object DefaultCodecs {
 
   implicit val publicKeyCodec: Codec[PublicKey] =

--- a/scalanet/discovery/src/io/iohk/scalanet/kademlia/KBuckets.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/kademlia/KBuckets.scala
@@ -74,15 +74,13 @@ class KBuckets[T <: BitVector] private (
 
       // buckets with elements closer to nodeId that baseId, sorted appropriately
       def closerBuckets: Iterator[Seq[T]] =
-        Range(buckets.size - 1, -1, -1)
-          .iterator
+        Range(buckets.size - 1, -1, -1).iterator
           .filter(i => nodeId(buckets.size - i - 1) != baseId(buckets.size - i - 1))
           .map(i => buckets(i).toSeq)
 
       // buckets with elements farther from nodeId than baseId, sorted appropriately
       def furtherBuckets: Iterator[Seq[T]] =
-        Range(0, buckets.size, 1)
-          .iterator
+        Range(0, buckets.size, 1).iterator
           .filter(i => nodeId(buckets.size - i - 1) == baseId(buckets.size - i - 1))
           .map(i => buckets(i).toSeq)
 

--- a/scalanet/discovery/src/io/iohk/scalanet/kademlia/TimeSet.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/kademlia/TimeSet.scala
@@ -28,7 +28,7 @@ class TimeSet[T] private (val clock: Clock, val timestamps: HashMap[T, Long], va
   override def iterator: Iterator[T] =
     underlying.iterator
 
-  def diff(that: Set[T]): Set[T] = 
+  def diff(that: Set[T]): Set[T] =
     underlying &~ that
 
   def touch(elem: T): TimeSet[T] =

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -2,10 +2,13 @@ package io.iohk.scalanet.peergroup
 
 import cats.effect.Resource
 import io.iohk.scalanet.peergroup.Channel.ChannelEvent
+import io.iohk.scalanet.peergroup.PeerGroup.PeerGroupWithProxySupport.Socks5Config
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent
 import monix.eval.Task
 import monix.reactive.Observable
 import scodec.Codec
+
+import java.net.InetSocketAddress
 
 /**
   * A Channel represents a route between two peers on the network for the purposes
@@ -106,6 +109,30 @@ trait PeerGroup[A, M] {
 object PeerGroup {
 
   abstract class TerminalPeerGroup[A, M](implicit codec: Codec[M]) extends PeerGroup[A, M]
+
+  abstract class PeerGroupWithProxySupport[A, M](implicit codec: Codec[M]) extends PeerGroup[A, M] {
+
+    /**
+      * This method builds a communication channel for the current peer to communicate messages with the
+      * desired address, going through proxy specified in proxy config
+      *
+      * @param to the address of the entity that would receive our messages. Note that this address can
+      *           be the address to refer to a single peer as well as a multicast address (to refer to a
+      *           set of peers).
+      * @param proxyConfig address and optional auth options to socks5 proxy
+      * @return the channel to interact with the desired peer(s).
+      */
+    def client(to: A, proxyConfig: Socks5Config): Resource[Task, Channel[A, M]]
+  }
+
+  object PeerGroupWithProxySupport {
+    final case class Sock5AuthenticationConfig(user: String, password: String)
+
+    final case class Socks5Config(
+        proxyAddress: InetSocketAddress,
+        authConfig: Option[Sock5AuthenticationConfig]
+    )
+  }
 
   sealed trait ServerEvent[A, M]
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -126,11 +126,11 @@ object PeerGroup {
   }
 
   object ProxySupport {
-    final case class Sock5AuthenticationConfig(user: String, password: String)
+    final case class Socks5AuthenticationConfig(user: String, password: String)
 
     final case class Socks5Config(
         proxyAddress: InetSocketAddress,
-        authConfig: Option[Sock5AuthenticationConfig]
+        authConfig: Option[Socks5AuthenticationConfig]
     )
 
     def apply[A, M](config: Socks5Config)(underlying: PeerGroup[A, M] with ProxySupport[A, M]): PeerGroup[A, M] =

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -10,14 +10,14 @@ import io.iohk.scalanet.crypto.CryptoUtils
 import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
-import io.iohk.scalanet.peergroup.PeerGroup.{PeerGroupWithProxySupport, ServerEvent}
+import io.iohk.scalanet.peergroup.PeerGroup.{ProxySupport, ServerEvent, TerminalPeerGroup}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKeyExtensionNodeData
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{Config, PeerInfo}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupInternals.{ClientChannelImpl, ServerChannelBuilder}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroupUtils.{SSLContextForClient, SSLContextForServer}
 import io.iohk.scalanet.peergroup.{Addressable, Channel, InetMultiAddress}
 import io.iohk.scalanet.peergroup.CloseableQueue
-import io.iohk.scalanet.peergroup.PeerGroup.PeerGroupWithProxySupport.Socks5Config
+import io.iohk.scalanet.peergroup.PeerGroup.ProxySupport.Socks5Config
 import io.netty.bootstrap.{Bootstrap, ServerBootstrap}
 import io.netty.channel._
 import io.netty.channel.nio.NioEventLoopGroup
@@ -46,7 +46,8 @@ import scala.util.control.NonFatal
 class DynamicTLSPeerGroup[M] private (val config: Config)(
     implicit codec: StreamCodec[M],
     scheduler: Scheduler
-) extends PeerGroupWithProxySupport[PeerInfo, M]
+) extends TerminalPeerGroup[PeerInfo, M]
+    with ProxySupport[PeerInfo, M]
     with StrictLogging {
 
   private val sslServerCtx: SslContext = DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForServer, config)

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.peergroup.Channel.{ChannelEvent, DecodingError, MessageReceived, UnexpectedError}
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
-import io.iohk.scalanet.peergroup.PeerGroup.PeerGroupWithProxySupport.Socks5Config
+import io.iohk.scalanet.peergroup.PeerGroup.ProxySupport.Socks5Config
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
 import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, HandshakeException, ServerEvent}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.PeerInfo

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -119,11 +119,8 @@ private[dynamictls] object DynamicTLSPeerGroupInternals {
           val sslHandler = sslClientCtx.newHandler(ch.alloc())
 
           socks5Config.foreach { config =>
-            val sock5Proxy = if (config.authConfig.isDefined) {
-              val authConfig = config.authConfig.get
+            val sock5Proxy = config.authConfig.fold(new Socks5ProxyHandler(config.proxyAddress)) { authConfig =>
               new Socks5ProxyHandler(config.proxyAddress, authConfig.user, authConfig.password)
-            } else {
-              new Socks5ProxyHandler(config.proxyAddress)
             }
             pipeline.addLast(sock5Proxy)
           }

--- a/scalanet/ut/src/io/iohk/scalanet/NetUtils.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/NetUtils.scala
@@ -13,13 +13,11 @@ object NetUtils {
 
   val keyStore: KeyStore = loadKeyStore("keystore.p12", "password")
   val trustStore: KeyStore = loadKeyStore("truststore.p12", "password")
-  @nowarn 
+  @nowarn
   val trustedCerts: Array[Certificate] = {
     import scala.collection.JavaConverters._
     trustStore.aliases().asScala.toArray.map(trustStore.getCertificate(_))
   }
-
-  
 
   def loadKeyStore(keystoreLocation: String, keystorePassword: String): KeyStore = {
     val keystore = KeyStore.getInstance("PKCS12")

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -1,5 +1,7 @@
 package io.iohk.scalanet.peergroup
 
+import cats.effect.Resource
+
 import java.net.InetSocketAddress
 import java.security.SecureRandom
 import cats.implicits._
@@ -11,6 +13,7 @@ import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
 import io.iohk.scalanet.peergroup.implicits._
 import io.iohk.scalanet.peergroup.Channel.{DecodingError, MessageReceived}
 import io.iohk.scalanet.peergroup.DynamicTLSPeerGroupSpec._
+import io.iohk.scalanet.peergroup.PeerGroup.PeerGroupWithProxySupport.Socks5Config
 import io.iohk.scalanet.peergroup.PeerGroup.{ChannelBrokenException, ChannelSetupException, HandshakeException}
 import io.iohk.scalanet.peergroup.ReqResponseProtocol.DynamicTLS
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKey
@@ -19,6 +22,7 @@ import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.{Config, PeerIn
 import io.iohk.scalanet.testutils.GeneratorUtils
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.scalatest.Matchers._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.concurrent.ScalaFutures._
@@ -26,6 +30,7 @@ import org.scalatest.{Assertion, AsyncFlatSpec, BeforeAndAfterAll}
 import scodec.Codec
 import scodec.bits.BitVector
 import scodec.codecs.implicits._
+import sockslib.server.{SocksProxyServer, SocksProxyServerFactory}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -55,6 +60,33 @@ class DynamicTLSPeerGroupSpec extends AsyncFlatSpec with BeforeAndAfterAll {
             case (ch, release) => ch.channelEventObservable.guarantee(release)
           }.headL
         } yield {
+          rec shouldEqual MessageReceived("Hello enc server")
+        }
+    }
+  }
+
+  it should "handshake successfully via proxy" in taskTestCase {
+    (for {
+      client <- DynamicTLSPeerGroup[String](getCorrectConfig())
+      proxy <- buildProxyServer(1080)
+      server <- DynamicTLSPeerGroup[String](getCorrectConfig())
+      ch1 <- client.client(server.processAddress, Socks5Config(new InetSocketAddress("localhost", 1080), None))
+    } yield (server, ch1, proxy)).use {
+      case (server, ch1, proxy) =>
+        for {
+          _ <- ch1.sendMessage("Hello enc server")
+          wo <- server.serverEventObservable.collectChannelCreated.mergeMap {
+            case (ch, release) =>
+              Observable(ch).zip(ch.channelEventObservable.guarantee(release))
+
+          }.headL
+          sessions <- Task(proxy.getSessionManager.getManagedSessions)
+          (chan, rec) = wo
+        } yield {
+          assert(sessions.size() == 1)
+          val session = sessions.get(1.toLong)
+          assert(session.getNetworkMonitor.getReceiveTCP > 0)
+          assert(session.getNetworkMonitor.getSendTCP > 0)
           rec shouldEqual MessageReceived("Hello enc server")
         }
     }
@@ -277,4 +309,15 @@ object DynamicTLSPeerGroupSpec {
     )
   }
 
+  def buildProxyServer(port: Int): Resource[Task, SocksProxyServer] = {
+    Resource.make {
+      Task {
+        val proxyServer = SocksProxyServerFactory.newNoAuthenticationServer(port)
+        proxyServer.start()
+        proxyServer
+      }
+    } { server =>
+      Task(server.shutdown())
+    }
+  }
 }


### PR DESCRIPTION
Easiest way to integrate with one other project is through their socks5 proxy. So to ease up initial experiments, adds socks5 proxy support to scalanet (thorough nett)