### PR TITLE
Add larger timeouts in release script

### DIFF
--- a/.circleci/publish
+++ b/.circleci/publish
@@ -20,6 +20,8 @@ mill mill.scalalib.PublishModule/publishAll \
     __.publishArtifacts \
     "$OSS_USERNAME":"$OSS_PASSWORD" \
     --gpgArgs --passphrase="$GPG_PASSPHRASE",--batch,--yes,-a,-b \
+    --readTimeout 600000 \
+    --awaitTimeout 600000 \
     --release true
 
 else


### PR DESCRIPTION
It seems timeouts for release should be higher - values copied from https://github.com/lihaoyi/mill/blob/master/ci/release-maven.sh