### PR TITLE
[Fix] Increase release timeout on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             - run:
                 name: publish
                 command: .circleci/publish
+                no_output_timeout: 30m
 
       # scoverage disabled
       #- store_artifacts:


### PR DESCRIPTION
During last release `0.6.0` CircleCi failed halfway during publishing process, this led to release being not finished. I needed to close and release staging repository manually. 

This pr increases this timeout to half and hour which should be enough.