### PR TITLE
[PM-2726] Add new validations from libp2p specs

### DIFF
--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomTlsValidator.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomTlsValidator.scala
@@ -3,12 +3,17 @@ package io.iohk.scalanet.peergroup.dynamictls
 import java.security.cert.{CertificateException, X509Certificate}
 import io.iohk.scalanet.crypto.CryptoUtils
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.SignedKey
+import org.bouncycastle.asn1.ASN1Primitive
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.asn1.x9.X962Parameters
 import org.joda.time.DateTime
 import scodec.bits.BitVector
-
+import java.security.interfaces.ECPublicKey
 import scala.util.{Failure, Success, Try}
 
-object CustomTlsValidator {
+private[scalanet] object CustomTlsValidator {
+  private val knownCertificateExtension = SignedKey.extensionIdentifier
+
   sealed abstract class CertificateError(msg: String) extends CertificateException(msg)
   case object WrongNumberOfCertificates extends CertificateError("Number of certificates not equal 1")
   case object WrongCertificateDate extends CertificateError("Certificate is expired or not yet valid")
@@ -16,6 +21,11 @@ object CustomTlsValidator {
   case object WrongExtensionFormat extends CertificateError("Extension has invalid format")
   case object WrongExtensionSignature extends CertificateError("Signature on cert extension is invalid")
   case object ServerIdNotMatchExpected extends CertificateError("Server id do not match expected")
+  case object WrongCertificateSelfSignature extends CertificateError("Certificate has wrong self-signature")
+  case object NotKnownCriticalExtensions extends CertificateError("Certificate contains not known critical extensions")
+  case object WrongCertificateKeyFormat
+      extends CertificateError("Certificate key should be EC key in NamedCurve Format")
+  case object WrongCertificateSignatureScheme extends CertificateError("Wrong signature scheme")
 
   /**
     *
@@ -47,6 +57,19 @@ object CustomTlsValidator {
 
   /**
     *
+    * Endpoints MUST abort the connection attempt if more than one certificate is received,
+    * or if the certificate’s self-signature is not valid.
+    *
+    */
+  private def validateCertificateSelfSig(cert: X509Certificate): Either[CertificateError, Unit] = {
+    Try(cert.verify(cert.getPublicKey)) match {
+      case Failure(_) => Left(WrongCertificateSelfSignature)
+      case Success(_) => Right(())
+    }
+  }
+
+  /**
+    *
     * The certificate MUST have NotBefore and NotAfter fields set such that the certificate is valid
     * at the time it is received by the peer
     *
@@ -59,27 +82,95 @@ object CustomTlsValidator {
   }
 
   /**
+    * Similarly, hash functions with an output length less than 256 bits MUST NOT be used,
+    * due to the possibility of collision attacks. In particular, MD5 and SHA1 MUST NOT be used
+    *
+    * Endpoints MUST choose a key that will allow the peer to verify the certificate
+    * and SHOULD use a key type that (a) allows for efficient signature computation,
+    * and (b) reduces the combined size of the certificate and the signature.
+    * In particular, RSA SHOULD NOT be used unless no elliptic curve algorithms are supported
+    *
+    * Taking both into account we force using "SHA256withECDSA"
+    */
+  private def validateCertificateSignatureScheme(cert: X509Certificate): Either[CertificateError, Unit] = {
+    val sigAlgName = cert.getSigAlgName
+    if (sigAlgName.equalsIgnoreCase(CryptoUtils.SHA256withECDSA.name)) {
+      Right(())
+    } else {
+      Left(WrongCertificateSignatureScheme)
+    }
+  }
+
+  /**
     *
     * Peers MUST verify the signature, and abort the connection attempt if signature verification fails
     *
     */
   private def validateCertificateSignature(
       signedKey: SignedKey,
-      cert: X509Certificate
+      certPublicKey: ECPublicKey
   ): Either[CertificateError, Unit] = {
-    val certificatePublicKey = cert.getPublicKey
     (for {
       // Certificate keys have different implementation (sun), to use our other machinery it need to be converted to Bouncy
       // castle format
       pubKeyInBcFormat <- CryptoUtils.getBouncyCastlePubKey(
-        certificatePublicKey.getEncoded,
-        certificatePublicKey.getAlgorithm
+        certPublicKey.getEncoded,
+        certPublicKey.getAlgorithm
       )
       keyBytes <- CryptoUtils.getEcPublicKey(pubKeyInBcFormat)
       result <- Try(SignedKey.verifySignature(signedKey, keyBytes))
     } yield result) match {
       case Failure(_) | Success(false) => Left(WrongExtensionSignature)
       case Success(true) => Right(())
+    }
+  }
+
+  /**
+    *
+    * Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
+    * Endpoints MUST abort the connection attempt if is not used.
+    *
+    */
+  def validateCertificatePublicKey(cert: X509Certificate): Either[CertificateError, ECPublicKey] = {
+    val certificatePublicKey = cert.getPublicKey
+    Try {
+      val ecPublicKey = certificatePublicKey.asInstanceOf[ECPublicKey]
+      val subjectKeyInfo = SubjectPublicKeyInfo.getInstance(ASN1Primitive.fromByteArray(ecPublicKey.getEncoded))
+      val x962Params = X962Parameters.getInstance(subjectKeyInfo.getAlgorithm.getParameters)
+      (ecPublicKey, x962Params)
+    }.toEither.left.map(_ => WrongCertificateKeyFormat).flatMap {
+      case (key, parameters) =>
+        if (parameters.isNamedCurve) {
+          Right(key)
+        } else {
+          Left(WrongCertificateKeyFormat)
+        }
+    }
+  }
+
+  /**
+    *
+    * The certificate MUST contain the libp2p Public Key Extension. If this extension is missing,
+    * endpoints MUST abort the connection attempt
+    *
+    * Endpoints MUST abort the connection attempt if the certificate contains critical extensions
+    * that the endpoint does not understand.
+    */
+  private def validateCertificateExtension(
+      cert: X509Certificate,
+      extensionId: String
+  ): Either[CertificateError, Array[Byte]] = {
+    Option(cert.getExtensionValue(extensionId)).toRight(NoCertExtension).flatMap { extension =>
+      val criticalExtensions = cert.getCriticalExtensionOIDs
+
+      val containsOnlyOneKnownCriticalExtension = criticalExtensions.size() == 0 ||
+        (criticalExtensions.size() == 1 && criticalExtensions.contains(knownCertificateExtension))
+
+      if (containsOnlyOneKnownCriticalExtension) {
+        Right(extension)
+      } else {
+        Left(NotKnownCriticalExtensions)
+      }
     }
   }
 
@@ -94,31 +185,16 @@ object CustomTlsValidator {
   ): Either[CertificateError, SignedKey] = {
     for {
       cert <- validateCertificatesQuantity(certificates)
+      _ <- validateCertificateSignatureScheme(cert)
+      _ <- validateCertificateSelfSig(cert)
       _ <- validateCertificateDate(cert)
+      validPublicKey <- validateCertificatePublicKey(cert)
       extension <- validateCertificateExtension(cert, SignedKey.extensionIdentifier)
       signedKeyExtension <- validateExtension(extension)
-      _ <- validateCertificateSignature(signedKeyExtension, cert)
+      _ <- validateCertificateSignature(signedKeyExtension, validPublicKey)
       _ <- if (connectingTo.isDefined) validateServerId(signedKeyExtension, connectingTo.get) else Right(())
     } yield {
       signedKeyExtension
-    }
-  }
-
-  /**
-    *
-    * The certificate MUST contain the libp2p Public Key Extension. If this extension is missing,
-    * endpoints MUST abort the connection attempt
-    *
-    */
-  private def validateCertificateExtension(
-      cert: X509Certificate,
-      extensionId: String
-  ): Either[CertificateError, Array[Byte]] = {
-    val extension = cert.getExtensionValue(extensionId)
-    if (extension == null) {
-      Left(NoCertExtension)
-    } else {
-      Right(extension)
     }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -7,7 +7,7 @@ import cats.effect.Resource
 import com.typesafe.scalalogging.StrictLogging
 import io.iohk.scalanet.codec.StreamCodec
 import io.iohk.scalanet.crypto.CryptoUtils
-import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.crypto.CryptoUtils.{SHA256withECDSA, Secp256r1}
 import io.iohk.scalanet.peergroup.ControlEvent.InitializationError
 import io.iohk.scalanet.peergroup.InetPeerGroupUtils.toTask
 import io.iohk.scalanet.peergroup.PeerGroup.{ProxySupport, ServerEvent, TerminalPeerGroup}
@@ -152,7 +152,7 @@ object DynamicTLSPeerGroup {
         secureRandom: SecureRandom
     ): Try[Config] = {
 
-      SignedKeyExtensionNodeData(keyType, hostKeyPair, Secp256r1, secureRandom).map { nodeData =>
+      SignedKeyExtensionNodeData(keyType, hostKeyPair, Secp256r1, secureRandom, SHA256withECDSA).map { nodeData =>
         Config(
           bindAddress,
           PeerInfo(nodeData.calculatedNodeId, InetMultiAddress(bindAddress)),

--- a/scalanet/ut/src/io/iohk/scalanet/dynamictls/CustomTlsValidatorSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/dynamictls/CustomTlsValidatorSpec.scala
@@ -2,11 +2,13 @@ package io.iohk.scalanet.dynamictls
 
 import java.security.SecureRandom
 import io.iohk.scalanet.crypto.CryptoUtils
-import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.crypto.CryptoUtils.{SHA256withECDSA, Secp256r1, SignatureScheme}
 import io.iohk.scalanet.peergroup.dynamictls.CustomTlsValidator.{
   NoCertExtension,
+  NotKnownCriticalExtensions,
   ServerIdNotMatchExpected,
   WrongCertificateDate,
+  WrongCertificateSignatureScheme,
   WrongExtensionFormat,
   WrongExtensionSignature,
   WrongNumberOfCertificates
@@ -14,7 +16,7 @@ import io.iohk.scalanet.peergroup.dynamictls.CustomTlsValidator.{
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.{Extension, SignedKey, SignedKeyExtensionNodeData}
 import io.iohk.scalanet.peergroup.dynamictls.{CustomTlsValidator, DynamicTLSExtension, Secp256k1}
 import io.iohk.scalanet.testutils.GeneratorUtils
-import org.bouncycastle.asn1.DERGeneralString
+import org.bouncycastle.asn1.{ASN1ObjectIdentifier, DERGeneralString}
 import org.joda.time.DateTime
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
 import org.scalatest.{FlatSpec, Matchers}
@@ -28,7 +30,7 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
 
   "CustomTlsValidator" should "successfully validate client certificates" in {
     forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
-      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd, SHA256withECDSA).get
       val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), None)
       assert(result.isRight)
     }
@@ -36,17 +38,26 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
 
   it should "successfully validate server certificates" in {
     forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { keyPair =>
-      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+      val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd, SHA256withECDSA).get
       val result =
         CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), Some(extension.calculatedNodeId))
       assert(result.isRight)
     }
   }
 
+  it should "fail to validate certificate signed by wrong algorithm" in {
+    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val extension =
+      SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd, new SignatureScheme("SHA224withECDSA") {}).get
+    val result =
+      CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), Some(extension.calculatedNodeId))
+    assert(result == Left(WrongCertificateSignatureScheme))
+  }
+
   it should "fail to validate server with bad id" in {
     forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd), GeneratorUtils.byteArrayOfNItemsGen(64)) {
       (keyPair, badId) =>
-        val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+        val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd, SHA256withECDSA).get
         val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), Some(BitVector(badId)))
         assert(result == Left(ServerIdNotMatchExpected))
     }
@@ -54,7 +65,7 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
 
   it should "fail to validate wrong number of certificates" in {
     val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
-    val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd).get
+    val extension = SignedKeyExtensionNodeData(Secp256k1, keyPair, Secp256r1, rnd, SHA256withECDSA).get
 
     val result = CustomTlsValidator.validateCertificates(Array(extension.certWithExtension), None)
     assert(result.isRight)
@@ -67,18 +78,50 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
     assert(result2 == Left(WrongNumberOfCertificates))
   }
 
+  it should "fail to validate certificate with not known critical extensions" in {
+    val keyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
+    val knownCriticalExtension =
+      Extension(SignedKey.signedKeyExtensionIdentifier, isCritical = true, new DERGeneralString("randomstring"))
+
+    val notKnownCriticalExtensions =
+      Extension(
+        new ASN1ObjectIdentifier("1.3.6.1.4.1.53594.1.2"),
+        isCritical = true,
+        new DERGeneralString("randomstring")
+      )
+
+    val cert = CryptoUtils.buildCertificateWithExtensions(
+      keyPair,
+      rnd,
+      List(knownCriticalExtension, notKnownCriticalExtensions),
+      beforeDate,
+      afterDate,
+      SHA256withECDSA
+    )
+
+    val result = CustomTlsValidator.validateCertificates(Array(cert), None)
+    assert(result == Left(NotKnownCriticalExtensions))
+  }
+
   it should "fail to validate certificate without required extension" in {
-    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
-    val cer = CryptoUtils.buildCertificateWithExtensions(keyPair, rnd, List(), beforeDate, afterDate)
+    val keyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
+    val cer = CryptoUtils.buildCertificateWithExtensions(keyPair, rnd, List(), beforeDate, afterDate, SHA256withECDSA)
     val result = CustomTlsValidator.validateCertificates(Array(cer), None)
     assert(result == Left(NoCertExtension))
   }
 
   it should "fail to validate certificate with some wrong extension" in {
-    val keyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
+    val keyPair = CryptoUtils.genTlsSupportedKeyPair(rnd, Secp256r1)
     val badExtension =
       Extension(SignedKey.signedKeyExtensionIdentifier, isCritical = true, new DERGeneralString("randomstring"))
-    val cer = CryptoUtils.buildCertificateWithExtensions(keyPair, rnd, List(badExtension), beforeDate, afterDate)
+    val cer = CryptoUtils.buildCertificateWithExtensions(
+      keyPair,
+      rnd,
+      List(badExtension),
+      beforeDate,
+      afterDate,
+      SHA256withECDSA
+    )
     val result = CustomTlsValidator.validateCertificates(Array(cer), None)
     assert(result == Left(WrongExtensionFormat))
   }
@@ -92,13 +135,27 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
 
     val notValidBeforeDate = DateTime.now().plusYears(1).toDate
     val cer =
-      CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), notValidBeforeDate, afterDate)
+      CryptoUtils.buildCertificateWithExtensions(
+        connectionKeyPair,
+        rnd,
+        List(extension),
+        notValidBeforeDate,
+        afterDate,
+        SHA256withECDSA
+      )
     val result = CustomTlsValidator.validateCertificates(Array(cer), None)
     assert(result == Left(WrongCertificateDate))
 
     val notValidAfterDate = DateTime.now().minusDays(1).toDate
     val cer1 =
-      CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), beforeDate, notValidAfterDate)
+      CryptoUtils.buildCertificateWithExtensions(
+        connectionKeyPair,
+        rnd,
+        List(extension),
+        beforeDate,
+        notValidAfterDate,
+        SHA256withECDSA
+      )
     val result1 = CustomTlsValidator.validateCertificates(Array(cer1), None)
     assert(result1 == Left(WrongCertificateDate))
   }
@@ -109,7 +166,14 @@ class CustomTlsValidatorSpec extends FlatSpec with Matchers {
     val fakeKey = BitVector(GeneratorUtils.byteArrayOfNItemsGen(64).sample.get)
     val (_, extension) = SignedKey.buildSignedKeyExtension(Secp256k1, hostkeyPair, fakeKey, rnd).require
 
-    val cer = CryptoUtils.buildCertificateWithExtensions(connectionKeyPair, rnd, List(extension), beforeDate, afterDate)
+    val cer = CryptoUtils.buildCertificateWithExtensions(
+      connectionKeyPair,
+      rnd,
+      List(extension),
+      beforeDate,
+      afterDate,
+      SHA256withECDSA
+    )
     val result = CustomTlsValidator.validateCertificates(Array(cer), None)
     assert(result == Left(WrongExtensionSignature))
   }

--- a/scalanet/ut/src/io/iohk/scalanet/dynamictls/SignedKeyExtensionSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/dynamictls/SignedKeyExtensionSpec.scala
@@ -1,9 +1,8 @@
 package io.iohk.scalanet.dynamictls
 
 import java.security.SecureRandom
-
 import io.iohk.scalanet.crypto.CryptoUtils
-import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.crypto.CryptoUtils.{SHA256withECDSA, Secp256r1}
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSExtension.{
   ExtensionPublicKey,
   SignedKey,
@@ -48,14 +47,14 @@ class SignedKeyExtensionSpec extends FlatSpec with Matchers {
 
   it should "successfully build extension node data" in {
     forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { hostKey =>
-      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd)
+      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd, SHA256withECDSA)
       assert(nodeData.isSuccess)
     }
   }
 
   it should "successfully parse node data from extension" in {
     forAll(GeneratorUtils.genKey(Secp256k1.curveName, rnd)) { hostKey =>
-      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd).get
+      val nodeData = SignedKeyExtensionNodeData(Secp256k1, hostKey, Secp256r1, rnd, SHA256withECDSA).get
       val extensionBytes = nodeData.certWithExtension.getExtensionValue(SignedKey.extensionIdentifier)
       val recoveredSignedKey = SignedKey.parseAsn1EncodedValue(extensionBytes)
       assert(recoveredSignedKey.isSuccessful)

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -9,7 +9,7 @@ import cats.effect.concurrent.Deferred
 import io.iohk.scalanet.NetUtils._
 import io.iohk.scalanet.codec.FramingCodec
 import io.iohk.scalanet.crypto.CryptoUtils
-import io.iohk.scalanet.crypto.CryptoUtils.Secp256r1
+import io.iohk.scalanet.crypto.CryptoUtils.{SHA256withECDSA, Secp256r1}
 import io.iohk.scalanet.peergroup.implicits._
 import io.iohk.scalanet.peergroup.Channel.{DecodingError, MessageReceived}
 import io.iohk.scalanet.peergroup.DynamicTLSPeerGroupSpec._
@@ -305,7 +305,8 @@ object DynamicTLSPeerGroupSpec {
       rnd,
       List(extension),
       validInterval.getStart.toDate,
-      validInterval.getEnd.toDate
+      validInterval.getEnd.toDate,
+      SHA256withECDSA
     )
 
     DynamicTLSPeerGroup.Config(


### PR DESCRIPTION
# Description

Add new validations from libp2p specs: 
- certificate self-signature validation
- validation that certificate signature is correct type - we force all signatures in dynamic tls peergroup to be ecdsa with sha256
- validation that certificate use NamedCurve encoding for elliptic curve parameters (public key)
- validation that certificate does not contain unknown critical extensions - in our case it should have at most one extension, which is extension to encode host public key

Also created ticket to refactor a little crypto code - https://jira.iohk.io/browse/PM-2744 as with all those additions it is getting a little out of hand.
