### PR TITLE
[PM-2752] Throttle incoming connections from the same ip

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -150,7 +150,8 @@ class ScalanetModule(crossVersion: String) extends Module {
       ivy"org.scodec::scodec-core:1.11.7",
       ivy"org.bouncycastle:bcprov-jdk15on:1.64",
       ivy"org.bouncycastle:bcpkix-jdk15on:1.64",
-      ivy"org.bouncycastle:bctls-jdk15on:1.64"
+      ivy"org.bouncycastle:bctls-jdk15on:1.64",
+      ivy"com.github.ben-manes.caffeine:caffeine:2.8.8"
     )
 
     def scoverageVersion = "1.3.1"

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -261,7 +261,7 @@ object ReqResponseProtocol {
     val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
 
     for {
-      config <- Resource.liftF(Task.fromTry(DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd)))
+      config <- Resource.liftF(Task.fromTry(DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd, None)))
       pg <- DynamicTLSPeerGroup[MessageEnvelope[M]](config)
       prot <- buildProtocol(pg)
     } yield prot

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomHandlers.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/CustomHandlers.scala
@@ -1,0 +1,33 @@
+package io.iohk.scalanet.peergroup.dynamictls
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.ipfilter.AbstractRemoteAddressFilter
+
+import java.net.{InetAddress, InetSocketAddress}
+
+private[scalanet] object CustomHandlers {
+  // to share handlers between pipelines they need to be marked as @Sharable, if not netty refuses to share it.
+  @Sharable
+  class ThrottlingIpFilter(config: DynamicTLSPeerGroup.IncomingConnectionThrottlingConfig)
+      extends AbstractRemoteAddressFilter[InetSocketAddress] {
+    private val cache = Caffeine
+      .newBuilder()
+      .expireAfterWrite(config.throttlingDuration.length, config.throttlingDuration.unit)
+      .build[InetAddress, java.lang.Boolean]()
+    private val cacheView = cache.asMap()
+
+    private def addIfAbsent(address: InetAddress): Boolean = {
+      cacheView.putIfAbsent(address, java.lang.Boolean.TRUE) == null
+    }
+
+    override def accept(ctx: ChannelHandlerContext, remoteAddress: InetSocketAddress): Boolean = {
+      val address = remoteAddress.getAddress
+      val throttleLocalAddress = (address.isLoopbackAddress && !config.throttleLocalhost)
+
+      throttleLocalAddress || addIfAbsent(address)
+    }
+  }
+
+}

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/ThrottlingIpFilterSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/ThrottlingIpFilterSpec.scala
@@ -1,0 +1,69 @@
+package io.iohk.scalanet.peergroup
+
+import io.iohk.scalanet.peergroup.dynamictls.CustomHandlers.ThrottlingIpFilter
+import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.IncomingConnectionThrottlingConfig
+import io.netty.channel.ChannelHandlerContext
+import org.scalatest.FlatSpec
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class ThrottlingIpFilterSpec extends FlatSpec with Eventually {
+  override implicit val patienceConfig = PatienceConfig(timeout = Span(600, Millis))
+
+  "ThrottlingIpFilter" should "do not accept connection from same ip one after another" in new TestSetup {
+    assert(filter.accept(mockContext, randomIp1))
+    assert(!filter.accept(mockContext, randomIp1))
+  }
+
+  it should "allow connection from different ips" in new TestSetup {
+    assert(filter.accept(mockContext, randomIp1))
+    assert(filter.accept(mockContext, randomIp2))
+  }
+
+  it should "eventually allow connections from same ip" in new TestSetup {
+    assert(filter.accept(mockContext, randomIp1))
+    assert(!filter.accept(mockContext, randomIp1))
+    eventually {
+      assert(filter.accept(mockContext, randomIp1))
+    }
+  }
+
+  it should "allow repeated connections from localhost when configured" in new TestSetup {
+    assert(filter.accept(mockContext, localHostAddress))
+    assert(filter.accept(mockContext, localHostAddress))
+  }
+
+  it should "disallow repeated connections from localhost when configured" in new TestSetup {
+    val throttleLocal = defaultConfig.copy(throttleLocalhost = true)
+    val filterWithLocalThrottling = new ThrottlingIpFilter(throttleLocal)
+    assert(filterWithLocalThrottling.accept(mockContext, localHostAddress))
+    assert(!filterWithLocalThrottling.accept(mockContext, localHostAddress))
+  }
+
+  it should "eventually allow repeated connections from localhost when throttling is configured" in new TestSetup {
+    val throttleLocal = defaultConfig.copy(throttleLocalhost = true)
+    val filterWithLocalThrottling = new ThrottlingIpFilter(throttleLocal)
+    assert(filterWithLocalThrottling.accept(mockContext, localHostAddress))
+    assert(!filterWithLocalThrottling.accept(mockContext, localHostAddress))
+    eventually {
+      assert(filterWithLocalThrottling.accept(mockContext, localHostAddress))
+    }
+  }
+
+  trait TestSetup {
+    val defaultConfig = IncomingConnectionThrottlingConfig(throttleLocalhost = false, throttlingDuration = 500.millis)
+
+    val mockContext = mock[ChannelHandlerContext]
+
+    val filter = new ThrottlingIpFilter(defaultConfig)
+
+    val randomIp1 = new InetSocketAddress("90.34.1.20", 90)
+    val randomIp2 = new InetSocketAddress("90.34.1.21", 90)
+    val localHostAddress = new InetSocketAddress("127.0.0.1", 90)
+  }
+
+}


### PR DESCRIPTION
# Description

Create a possibility to throttle incoming connections from the same ip.

Some of design decisions:
- I did not add `maxSize` property to cache as it with typical throttling times (like lets say `30s`) it would be really hard to use up all host memory. (Ip4 address takes 4bytes, so 1M of them would take only 4Mb + some overhead for java object fields)
- I decided to use caffeine cache with `exipreAfterWrite` property. The similar effect could be accomplished by using java concurrent hash map, and scheduling clearing on netty eventLoops, but ultimately I think cache solution is clearer and worth bringing another dependency
- I decided to not give user of the group option to sent a message when closing the channel which violates throttling restrictions. By default we are treating connections which violates throttling restrictions as hostile and want to give it as little information as possilbe.
