### PR TITLE
[PM-1902] TLS 1.3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -144,6 +144,7 @@ class ScalanetModule(crossVersion: String) extends Module {
       ivy"com.github.jgonian:commons-ip-math:1.32",
       ivy"org.slf4j:slf4j-api:1.7.25",
       ivy"io.netty:netty-all:4.1.58.Final",
+      ivy"io.netty:netty-tcnative-boringssl-static:2.0.36.Final",
       ivy"org.eclipse.californium:scandium:2.0.0-M15",
       ivy"org.eclipse.californium:element-connector:2.0.0-M15",
       ivy"org.scodec::scodec-bits:1.1.12",

--- a/build.sc
+++ b/build.sc
@@ -143,7 +143,7 @@ class ScalanetModule(crossVersion: String) extends Module {
       ivy"com.typesafe.scala-logging::scala-logging:3.9.2",
       ivy"com.github.jgonian:commons-ip-math:1.32",
       ivy"org.slf4j:slf4j-api:1.7.25",
-      ivy"io.netty:netty-all:4.1.51.Final",
+      ivy"io.netty:netty-all:4.1.58.Final",
       ivy"org.eclipse.californium:scandium:2.0.0-M15",
       ivy"org.eclipse.californium:element-connector:2.0.0-M15",
       ivy"org.scodec::scodec-bits:1.1.12",

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -261,7 +261,11 @@ object ReqResponseProtocol {
     val hostkeyPair = CryptoUtils.genEcKeyPair(rnd, Secp256k1.curveName)
 
     for {
-      config <- Resource.liftF(Task.fromTry(DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd, None)))
+      config <- Resource.liftF(
+        Task.fromTry(
+          DynamicTLSPeerGroup.Config(address, Secp256k1, hostkeyPair, rnd, useNativeTlsImplementation = false, None)
+        )
+      )
       pg <- DynamicTLSPeerGroup[MessageEnvelope[M]](config)
       prot <- buildProtocol(pg)
     } yield prot

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -157,6 +157,7 @@ object DynamicTLSPeerGroup {
       peerInfo: PeerInfo,
       connectionKeyPair: KeyPair,
       connectionCertificate: X509Certificate,
+      useNativeTlsImplementation: Boolean,
       incomingConnectionsThrottling: Option[IncomingConnectionThrottlingConfig]
   )
 
@@ -167,6 +168,7 @@ object DynamicTLSPeerGroup {
         keyType: KeyType,
         hostKeyPair: KeyPair,
         secureRandom: SecureRandom,
+        useNativeTlsImplementation: Boolean,
         incomingConnectionsThrottling: Option[IncomingConnectionThrottlingConfig]
     ): Try[Config] = {
 
@@ -176,6 +178,7 @@ object DynamicTLSPeerGroup {
           PeerInfo(nodeData.calculatedNodeId, InetMultiAddress(bindAddress)),
           nodeData.generatedConnectionKey,
           nodeData.certWithExtension,
+          useNativeTlsImplementation,
           incomingConnectionsThrottling
         )
       }
@@ -186,10 +189,18 @@ object DynamicTLSPeerGroup {
         keyType: KeyType,
         hostKeyPair: AsymmetricCipherKeyPair,
         secureRandom: SecureRandom,
+        useNativeTlsImplementation: Boolean,
         incomingConnectionsThrottling: Option[IncomingConnectionThrottlingConfig]
     ): Try[Config] = {
       val convertedKeyPair = CryptoUtils.convertBcToJceKeyPair(hostKeyPair)
-      Config(bindAddress, keyType, convertedKeyPair, secureRandom, incomingConnectionsThrottling)
+      Config(
+        bindAddress,
+        keyType,
+        convertedKeyPair,
+        secureRandom,
+        useNativeTlsImplementation,
+        incomingConnectionsThrottling
+      )
     }
   }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupUtils.scala
@@ -3,22 +3,14 @@ package io.iohk.scalanet.peergroup.dynamictls
 import java.net.Socket
 import java.security.KeyStore
 import java.security.cert.X509Certificate
-
 import io.iohk.scalanet.peergroup.dynamictls.DynamicTLSPeerGroup.PeerInfo
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory
 import io.netty.handler.ssl.{ClientAuth, SslContext, SslContextBuilder}
+
 import javax.net.ssl._
 import scodec.bits.BitVector
 
-import java.util.Arrays
-
 private[scalanet] object DynamicTLSPeerGroupUtils {
-  // supporting only ciphers which are used in TLS 1.3
-  private val supportedCipherSuites: java.lang.Iterable[String] = Arrays.asList(
-    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-  )
-
   // key for peerId passed in Handshake session, used in sslEngine
   val peerIdKey = "peerId"
 
@@ -87,8 +79,7 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
           .forServer(config.connectionKeyPair.getPrivate, List(config.connectionCertificate): _*)
           .trustManager(new CustomTrustManagerFactory(None))
           .clientAuth(ClientAuth.REQUIRE)
-          .ciphers(supportedCipherSuites)
-          .protocols("TLSv1.2")
+          .protocols("TLSv1.3")
           .build()
 
       case SSLContextForClient(info) =>
@@ -96,8 +87,7 @@ private[scalanet] object DynamicTLSPeerGroupUtils {
           .forClient()
           .keyManager(config.connectionKeyPair.getPrivate, List(config.connectionCertificate): _*)
           .trustManager(new CustomTrustManagerFactory(Some(info.id)))
-          .ciphers(supportedCipherSuites)
-          .protocols("TLSv1.2")
+          .protocols("TLSv1.3")
           .build()
     }
   }


### PR DESCRIPTION
# Description

Updates tls used to `TLS 1.3`. It seems tls 1.3 is now supported in both java8 and java11 (and newer versions) so when using jdk based tls there is no limits about jdk versions (except maybe to use newest possible version of java8). The details are in - https://github.com/netty/netty/commit/b1d3aad404a39143da7a86c121d60f35c0d21108

Also adds config option to use native versions of via statically linked jars with boring ssl. From various different netty presentations it seems that native ssl has 3x times larger throughput that jdk one. 
