### PR TITLE
[PM-3177] Add api to get channel local info

### DIFF
--- a/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockPeerGroup.scala
+++ b/scalanet/discovery/ut/src/io/iohk/scalanet/discovery/ethereum/v4/mocks/MockPeerGroup.scala
@@ -38,11 +38,11 @@ class MockPeerGroup[A, M](
   }
 
   def getOrCreateChannel(to: A): Task[MockChannel[A, M]] =
-    Task(channels.getOrElseUpdate(to, new MockChannel[A, M](to)))
+    Task(channels.getOrElseUpdate(to, new MockChannel[A, M](processAddress, to)))
 
   def createServerChannel(from: A): Task[MockChannel[A, M]] =
     for {
-      channel <- Task(new MockChannel[A, M](from))
+      channel <- Task(new MockChannel[A, M](processAddress, from))
       _ <- Task(channel.refCount.increment())
       event = ChannelCreated(channel, Task(channel.refCount.decrement()))
       _ <- serverEvents.offer(event)
@@ -50,6 +50,7 @@ class MockPeerGroup[A, M](
 }
 
 class MockChannel[A, M](
+    override val from: A,
     override val to: A
 )(implicit val s: Scheduler)
     extends Channel[A, M] {

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -28,6 +28,11 @@ import java.net.InetSocketAddress
 trait Channel[A, M] {
 
   /**
+    * The local address from this nodes point of view.
+    */
+  def from: A
+
+  /**
     * The remote address from this nodes point of view.
     */
   def to: A

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -79,6 +79,7 @@ class DynamicTLSPeerGroup[M] private (val config: Config)(
     .childHandler(new ChannelInitializer[SocketChannel]() {
       override def initChannel(ch: SocketChannel): Unit = {
         new ServerChannelBuilder[M](
+          config.peerInfo.id,
           serverQueue,
           ch,
           sslServerCtx,
@@ -110,6 +111,7 @@ class DynamicTLSPeerGroup[M] private (val config: Config)(
     Resource.make(
       Task.suspend {
         new ClientChannelBuilder[M](
+          config.peerInfo.id,
           to,
           clientBootstrap,
           DynamicTLSPeerGroupUtils.buildCustomSSlContext(SSLContextForClient(to), config),

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/DynamicUDPPeerGroup.scala
@@ -203,6 +203,8 @@ class DynamicUDPPeerGroup[M] private (val config: DynamicUDPPeerGroup.Config)(
       channelType: ChannelType
   ) extends Channel[InetMultiAddress, M] {
 
+    override def from: InetMultiAddress = InetMultiAddress(localAddress)
+
     val closePromise: Promise[ChannelImpl] = nettyChannel.eventLoop().newPromise[ChannelImpl]()
 
     val channelId = UDPChannelId(nettyChannel.id(), remoteAddress, localAddress)

--- a/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -369,6 +369,9 @@ object StaticUDPPeerGroup extends StrictLogging {
     override val to =
       InetMultiAddress(remoteAddress)
 
+    override def from: InetMultiAddress =
+      InetMultiAddress(localAddress)
+
     override def nextChannelEvent =
       messageQueue.next
 


### PR DESCRIPTION
# Description

Exposes local channel info for network channel, which may be usefull in some cases, for example, checking ephemeral port attached to outgoing `DynamicTlsPeerGroup` channel