### PR TITLE
[Pm-3178] Add idle peer detection to DynamicTlsPeerGrup

### DIFF
--- a/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/io/iohk/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -1,7 +1,7 @@
 package io.iohk.scalanet.discovery.ethereum.v4
 
 import cats.implicits._
-import cats.effect.{Clock}
+import cats.effect.Clock
 import cats.effect.concurrent.Deferred
 import com.typesafe.scalalogging.LazyLogging
 import io.iohk.scalanet.discovery.crypto.{PrivateKey, PublicKey, SigAlg}
@@ -10,17 +10,21 @@ import io.iohk.scalanet.discovery.hash.Hash
 import io.iohk.scalanet.peergroup.implicits.NextOps
 import io.iohk.scalanet.peergroup.{Addressable, Channel, PeerGroup}
 import io.iohk.scalanet.peergroup.PeerGroup.ServerEvent.ChannelCreated
-import io.iohk.scalanet.peergroup.Channel.{MessageReceived, DecodingError, UnexpectedError}
+import io.iohk.scalanet.peergroup.Channel.{ChannelIdle, DecodingError, MessageReceived, UnexpectedError}
+
 import java.util.concurrent.TimeoutException
 import java.net.InetAddress
 import monix.eval.Task
 import monix.tail.Iterant
 import monix.catnap.CancelableF
+
 import scala.concurrent.duration._
-import scodec.{Codec, Attempt}
-import scala.util.control.{NonFatal, NoStackTrace}
+import scodec.{Attempt, Codec}
+
+import scala.util.control.{NoStackTrace, NonFatal}
 import scodec.bits.BitVector
 import io.iohk.scalanet.discovery.ethereum.v4.Payload.Neighbors
+
 import java.net.InetSocketAddress
 import io.iohk.scalanet.discovery.hash.Keccak256
 
@@ -143,6 +147,10 @@ object DiscoveryNetwork {
 
             case UnexpectedError(ex) =>
               Task.raiseError(new PacketException(ex.getMessage))
+
+            case ChannelIdle(_, _) =>
+              // we do not use idle peer detection in discovery
+              Task.unit
           }
           .completedL
       }

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -76,7 +76,7 @@ object Channel {
     *  2. `first` flag means that this is the first idle event of given type since last activity i.e
     *       - in case `ReaderIdle -> AllIdle -> ReaderIdle`, the idle events look like:
     *       `ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(AllIdle, first = true) -> ChannelIdle(ReaderIdle, first = false)`
-    *       - in case `ReaderIdle -> IncomingRead -> ReaderIdle -> ReaderIdle`
+    *       - in case `ReaderIdle -> IncomingRead  -> ReaderIdle -> ReaderIdle`
     *       `ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(ReaderIdle, first = false)`
     *
     * @param idleState type of idle event

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -67,7 +67,22 @@ object Channel {
   final case class UnexpectedError(e: Throwable) extends ChannelEvent[Nothing]
   final case object DecodingError extends ChannelEvent[Nothing]
 
-  // only used in DynamicTlsPeerGroup
+  /**
+    *  only used in DynamicTlsPeerGroup, indicated that there was no action on particular channel
+    *  Basic rules regarding idle events:
+    *  1. Idle events are raised once per timeout i.e if reader idle time is configured to 5 second, then every
+    *     5 seconds ChannelIdle(ReaderIdle, _) event will be generated if there is no incoming traffic
+    *
+    *  2. `first` flag means that this is the first idle event of given type since last activity i.e
+    *       - in case `ReaderIdle -> AllIdle -> ReaderIdle`, the idle events look like:
+    *       `ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(AllIdle, first = true) -> ChannelIdle(ReaderIdle, first = false)`
+    *       - in case `ReaderIdle -> IncomingRead -> ReaderIdle -> ReaderIdle`
+    *       `ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(ReaderIdle, first = true) -> ChannelIdle(ReaderIdle, first = false)`
+    *
+    * @param idleState type of idle event
+    * @param first flag indicating if this is first idle event since last activity
+    *
+    */
   final case class ChannelIdle(idleState: IdleState, first: Boolean) extends ChannelEvent[Nothing]
 }
 

--- a/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/PeerGroup.scala
@@ -57,10 +57,18 @@ trait Channel[A, M] {
 }
 
 object Channel {
+  sealed abstract class IdleState
+  case object ReaderIdle extends IdleState
+  case object WriterIdle extends IdleState
+  case object AllIdle extends IdleState
+
   sealed abstract class ChannelEvent[+M]
   final case class MessageReceived[M](m: M) extends ChannelEvent[M]
   final case class UnexpectedError(e: Throwable) extends ChannelEvent[Nothing]
   final case object DecodingError extends ChannelEvent[Nothing]
+
+  // only used in DynamicTlsPeerGroup
+  final case class ChannelIdle(idleState: IdleState, first: Boolean) extends ChannelEvent[Nothing]
 }
 
 /**

--- a/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/ReqResponseProtocol.scala
@@ -238,6 +238,7 @@ object ReqResponseProtocol {
               useNativeTlsImplementation = false,
               framingConfig,
               maxIncomingMessageQueueSize = 100,
+              None,
               None
             )
         )

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -33,7 +33,7 @@ import scodec.Codec
 import scodec.bits.BitVector
 
 import java.nio.ByteOrder
-import scala.concurrent.duration.{FiniteDuration, TimeUnit}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -312,7 +312,6 @@ object DynamicTLSPeerGroup {
 
   /**
     * Configures detection on idle peer
-    * @param timeUnit unit of time for all time configs
     * @param readerIdleTime a ChannelIdle event whose state is ReaderIdle will be triggered when
     *                       no read was performed for the specified period of time on given channel. Specify 0 to disable.
     * @param writerIdleTime a ChannelIdle event whose state is WriterIdle will be triggered when
@@ -321,27 +320,11 @@ object DynamicTLSPeerGroup {
     *                      neither read nor write was performed for the specified period of time on given channel. Specify 0 to disable.
     *
     */
-  class StalePeerDetectionConfig private (
-      val timeUnit: TimeUnit,
-      val readerIdleTime: Long,
-      val writerIdleTime: Long,
-      val allIdleTime: Long
+  case class StalePeerDetectionConfig(
+      readerIdleTime: FiniteDuration,
+      writerIdleTime: FiniteDuration,
+      allIdleTime: FiniteDuration
   )
-
-  object StalePeerDetectionConfig {
-    def apply(
-        timeUnit: TimeUnit,
-        readerIdleTime: Long,
-        writerIdleTime: Long,
-        allIdleTime: Long
-    ): Either[ConfigError, StalePeerDetectionConfig] = {
-      if (readerIdleTime < 0 || writerIdleTime < 0 || allIdleTime < 0) {
-        Left(ConfigError("All time values should be non-negative"))
-      } else {
-        Right(new StalePeerDetectionConfig(timeUnit, readerIdleTime, writerIdleTime, allIdleTime))
-      }
-    }
-  }
 
   /**
     *

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -318,7 +318,7 @@ object DynamicTLSPeerGroup {
     * @param writerIdleTime a ChannelIdle event whose state is WriterIdle will be triggered when
     *                       no write was performed for the specified period of time on given channel. Specify 0 to disable.
     * @param allIdleTime a ChannelIdle event whose state is AllIdle will be triggered when
-    *                       no read was performed for the specified period of time on given channel. Specify 0 to disable.
+    *                      neither read nor write was performed for the specified period of time on given channel. Specify 0 to disable.
     *
     */
   class StalePeerDetectionConfig private (

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroup.scala
@@ -310,6 +310,17 @@ object DynamicTLSPeerGroup {
     */
   case class IncomingConnectionThrottlingConfig(throttleLocalhost: Boolean, throttlingDuration: FiniteDuration)
 
+  /**
+    * Configures detection on idle peer
+    * @param timeUnit unit of time for all time configs
+    * @param readerIdleTime a ChannelIdle event whose state is ReaderIdle will be triggered when
+    *                       no read was performed for the specified period of time on given channel. Specify 0 to disable.
+    * @param writerIdleTime a ChannelIdle event whose state is WriterIdle will be triggered when
+    *                       no write was performed for the specified period of time on given channel. Specify 0 to disable.
+    * @param allIdleTime a ChannelIdle event whose state is AllIdle will be triggered when
+    *                       no read was performed for the specified period of time on given channel. Specify 0 to disable.
+    *
+    */
   class StalePeerDetectionConfig private (
       val timeUnit: TimeUnit,
       val readerIdleTime: Long,
@@ -329,10 +340,23 @@ object DynamicTLSPeerGroup {
       } else {
         Right(new StalePeerDetectionConfig(timeUnit, readerIdleTime, writerIdleTime, allIdleTime))
       }
-
     }
   }
 
+  /**
+    *
+    * Configuration for DynamicTlsPeerGroup with all possible options
+    *
+    * @param bindAddress the interface to which server should be bind
+    * @param peerInfo local id of the peer and server address
+    * @param connectionKeyPair keyPair used in negotiating tls connections
+    * @param connectionCertificate  connection certificate of local node
+    * @param useNativeTlsImplementation should native or java tls implementation be used
+    * @param framingConfig details about framing on the wire
+    * @param maxIncomingMessageQueueSize max number of un-read messages per remote peer
+    * @param incomingConnectionsThrottling optional possibility to throttle incoming connections
+    * @param stalePeerDetectionConfig optional possibility to detect if remote peer is idle
+    */
   case class Config(
       bindAddress: InetSocketAddress,
       peerInfo: PeerInfo,

--- a/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/io/iohk/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -46,6 +46,8 @@ import io.netty.handler.timeout.{IdleState, IdleStateEvent, IdleStateHandler}
 import scodec.Attempt.{Failure, Successful}
 import scodec.Codec
 
+import java.util.concurrent.TimeUnit
+
 private[peergroup] object DynamicTLSPeerGroupInternals {
   def buildFramingCodecs(config: FramingConfig): (LengthFieldBasedFrameDecoder, LengthFieldPrepender) = {
     val encoder = new LengthFieldPrepender(
@@ -69,7 +71,12 @@ private[peergroup] object DynamicTLSPeerGroupInternals {
   }
 
   def buildIdlePeerHandler(config: StalePeerDetectionConfig): IdleStateHandler = {
-    new IdleStateHandler(config.readerIdleTime, config.writerIdleTime, config.allIdleTime, config.timeUnit)
+    new IdleStateHandler(
+      config.readerIdleTime.toMillis,
+      config.writerIdleTime.toMillis,
+      config.allIdleTime.toMillis,
+      TimeUnit.MILLISECONDS
+    )
   }
 
   implicit class ChannelOps(val channel: io.netty.channel.Channel) {

--- a/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
+++ b/scalanet/ut/src/io/iohk/scalanet/peergroup/DynamicTLSPeerGroupSpec.scala
@@ -56,7 +56,7 @@ import scodec.codecs.implicits._
 import sockslib.server.{SocksProxyServer, SocksProxyServerFactory}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
-import java.util.concurrent.{TimeUnit, TimeoutException}
+import java.util.concurrent.TimeoutException
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
@@ -140,19 +140,19 @@ class DynamicTLSPeerGroupSpec extends AsyncFlatSpec with BeforeAndAfterAll {
     it should s"generate ${label} event ${description}" in taskTestCase {
       val stalePeerDetectionConfig = idleEventType match {
         case Channel.ReaderIdle =>
-          StalePeerDetectionConfig(TimeUnit.SECONDS, 1, 0, 0).toOption
+          StalePeerDetectionConfig(1.second, 0.second, 0.second)
         case Channel.WriterIdle =>
-          StalePeerDetectionConfig(TimeUnit.SECONDS, 0, 1, 0).toOption
+          StalePeerDetectionConfig(0.second, 1.second, 0.second)
         case Channel.AllIdle =>
-          StalePeerDetectionConfig(TimeUnit.SECONDS, 0, 0, 1).toOption
+          StalePeerDetectionConfig(0.second, 0.second, 1.second)
       }
 
       (for {
         client <- DynamicTLSPeerGroup[String](
-          getCorrectConfig(stalePeerDetectionConfig = stalePeerDetectionConfig)
+          getCorrectConfig(stalePeerDetectionConfig = Some(stalePeerDetectionConfig))
         )
         server <- DynamicTLSPeerGroup[String](
-          getCorrectConfig(stalePeerDetectionConfig = stalePeerDetectionConfig)
+          getCorrectConfig(stalePeerDetectionConfig = Some(stalePeerDetectionConfig))
         )
         ch1 <- client.client(server.processAddress)
       } yield (client, server, ch1)).use {


### PR DESCRIPTION
# Description

Adds idle peer detection to DynamicTlsPeerGrup by using netty `IdleStateHandler`. This makes it possible to implement different stale peer detection schemes on top of this peer group.

Simplest one for static cluster would be to require all nodes in cluster to sends heart beats every `x` seconds, and configure `readerIdleTime` to the same `x` seconds, then number of   `ChanneIdle(ReaderIdle)` events will represent number of missed heartbeats from remote node. (of course this is only approximation, in reality, due to set of different factors heartbeats could be delayed or queued somewhere)